### PR TITLE
FIX comment  fatal error: 'rocksdb/c.h' file not found

### DIFF
--- a/internal/logdb/gorocksdb/backup.go
+++ b/internal/logdb/gorocksdb/backup.go
@@ -1,8 +1,8 @@
 package gorocksdb
 
 /*
-#include <stdlib.h>
-#include "rocksdb/c.h"
+//#include <stdlib.h>
+//#include "rocksdb/c.h"
 */
 import "C"
 import (


### PR DESCRIPTION
FIX
../github.com/lni/dragonboat/internal/logdb/gorocksdb/backup.go:5:10: fatal error: 'rocksdb/c.h' file not found