### PR TITLE
node should wait util initialized when there is master node

### DIFF
--- a/nodehost.go
+++ b/nodehost.go
@@ -258,7 +258,7 @@ func NewNodeHostWithMasterClientFactory(nhConfig config.NodeHostConfig,
 	nh.stopper.RunWorker(func() {
 		nh.tickWorkerMain()
 	})
-	if !nh.masterMode() {
+	if nh.masterMode() {
 		nh.waitUntilInitialized()
 	}
 	nh.logNodeHostDetails()


### PR DESCRIPTION
when there is master nodes,  node host should wait util initialized.
this prevent `nh.StartCluster` from panic because it's not initialized.