### PR TITLE
fix cpp binding statemachine factory

### DIFF
--- a/binding/cpp/dragonboat.cpp
+++ b/binding/cpp/dragonboat.cpp
@@ -328,7 +328,7 @@ Status NodeHost::StartCluster(const Peers& peers,
 }
 
 Status NodeHost::StartCluster(const Peers& peers, bool join,
-  CPPStateMachine*(*factory)(uint64_t clusterID, uint64_t nodeID),
+  StateMachine*(*factory)(uint64_t clusterID, uint64_t nodeID),
   Config config) noexcept
 {
   ::RaftConfig cfg;

--- a/binding/include/dragonboat/dragonboat.h
+++ b/binding/include/dragonboat/dragonboat.h
@@ -37,9 +37,6 @@
 // - Users can not specify custom logger to use in C++ applications.
 //
 
-// Forward declaration
-struct CPPStateMachine;
-
 namespace dragonboat {
 
 using Byte = unsigned char;
@@ -360,6 +357,7 @@ class IOService
   virtual void run() noexcept = 0;
 };
 
+class StateMachine;
 // NodeHost is the C++ wrapper of the Go NodeHost struct provided by the
 // github.com/lni/dragonboat/multiraft package.
 class NodeHost : public ManagedObject
@@ -391,7 +389,7 @@ class NodeHost : public ManagedObject
     bool join, std::string pluginFilepath, Config config) noexcept;
 
   Status StartCluster(const Peers& replicas, bool join,
-    CPPStateMachine*(*factory)(uint64_t clusterID, uint64_t nodeID),
+    StateMachine*(*factory)(uint64_t clusterID, uint64_t nodeID),
     Config config) noexcept;
   // StopCluster removes the specified cluster node from NodeHost. Note that
   // StopCluster makes the specified node no longer managed by the NodeHost

--- a/binding/tests/nodehost_tests.cpp
+++ b/binding/tests/nodehost_tests.cpp
@@ -952,12 +952,10 @@ class InPlaceHelloWorldStateMachine : public dragonboat::StateMachine
     int update_count_;
 };
 
-CPPStateMachine *CreateDragonboatFactoryStateMachine(uint64_t clusterID,
+dragonboat::StateMachine *CreateDragonboatFactoryStateMachine(uint64_t clusterID,
   uint64_t nodeID)
 {
-  CPPStateMachine *cds = new CPPStateMachine; 
-  cds->sm = new InPlaceHelloWorldStateMachine(clusterID, nodeID);
-  return cds;
+  return new InPlaceHelloWorldStateMachine(clusterID, nodeID);
 }
 
 TEST_F(NodeHostTest, ClusterFromCppFactoryCanBeAddedAndRemoved)

--- a/internal/cpp/wrapper.cpp
+++ b/internal/cpp/wrapper.cpp
@@ -69,8 +69,9 @@ CPPStateMachine *CreateDBStateMachine(uint64_t clusterID,
 CPPStateMachine *CreateDBStateMachineFromFactory(uint64_t clusterID,
   uint64_t nodeID, void *factory)
 {
-  auto fn = reinterpret_cast<CPPStateMachine *(*)(uint64_t, uint64_t)>(factory);
-  CPPStateMachine *ds = (*fn)(clusterID, nodeID);
+  auto fn = reinterpret_cast<dragonboat::StateMachine *(*)(uint64_t, uint64_t)>(factory);
+  CPPStateMachine *ds = new CPPStateMachine;
+  ds->sm = (*fn)(clusterID, nodeID);
   return ds;
 }
 


### PR DESCRIPTION
cpp binding statemachine factory should return dragonboat::StateMachine* instead of the CPPStateMachine*