### PR TITLE
quick fix for MkDir issue

### DIFF
--- a/internal/logdb/kv/rocksdb/kv_rocksdb.go
+++ b/internal/logdb/kv/rocksdb/kv_rocksdb.go
@@ -129,7 +129,7 @@ func openRocksDB(dir string, wal string) (*KV, error) {
 		return nil, err
 	}
 	if len(wal) > 0 && !walExist {
-		if err := fileutil.Mkdir(wal); err != nil {
+		if err := fileutil.MkdirAll(wal); err != nil {
 			plog.Panicf("cannot create dir for RDB WAL (%v)", err)
 		}
 	}
@@ -138,7 +138,7 @@ func openRocksDB(dir string, wal string) (*KV, error) {
 		return nil, err
 	}
 	if !dirExist {
-		if err := fileutil.Mkdir(dir); err != nil {
+		if err := fileutil.MkdirAll(dir); err != nil {
 			plog.Panicf("cannot create dir (%v)", err)
 		}
 	}


### PR DESCRIPTION
Hi,
I have the following observation: 
when I invoke tools.ImportSnapshot() and if the data directory of the new node is nested, the following error shows up:
'panic: cannot create dir for RDB WAL (mkdir example-data/node11/MacBook-Pro.local/00000000000000000001/logdb-0: no such file or directory)'

A quick fix is to change the fileutil.Mkdir() method to fileutil.MkdirAll() so that it handles nested directory properly. 
Not sure whether this is expected to be a feature though.