### PR TITLE
(WIP) Add witness role to Raft

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -65,6 +65,8 @@ type Config struct {
 	// IsObserver indicates whether this is an observer Raft node without voting
 	// power.
 	IsObserver bool
+	// IsWitness indicates whether this is a witness Raft node without real log data.
+	IsWitness bool
 	// CheckQuorum specifies whether the leader node should periodically check
 	// non-leader node status and step down to become a follower node when it no
 	// longer has the quorum.

--- a/execengine.go
+++ b/execengine.go
@@ -505,7 +505,7 @@ func (s *execEngine) execNodes(workerID uint64,
 	if tests.ReadyToReturnTestKnob(stopC, false, "sending append msg") {
 		return
 	}
-	// see raft thesis section 10.2.1 on details why we send Relicate message
+	// see raft thesis section 10.2.1 on details why we send Replicate message
 	// before those entries are persisted to disk
 	for _, ud := range nodeUpdates {
 		node := nodes[ud.ClusterID]

--- a/internal/raft/logentry.go
+++ b/internal/raft/logentry.go
@@ -53,7 +53,7 @@ type ILogDB interface {
 	SetState(ps pb.State)
 	// CreateSnapshot sets the snapshot known to ILogDB
 	CreateSnapshot(ss pb.Snapshot) error
-	// ApplySnapshot makes the sbapshot known to ILogDB and also update the entry
+	// ApplySnapshot makes the snapshot known to ILogDB and also update the entry
 	// range known to ILogDB.
 	ApplySnapshot(ss pb.Snapshot) error
 	// Term returns the entry term of the specified entry.

--- a/internal/raft/peer_test.go
+++ b/internal/raft/peer_test.go
@@ -60,7 +60,7 @@ func getTestMembership(nodes []uint64) pb.Membership {
 func TestRaftAPINodeStep(t *testing.T) {
 	for i := range pb.MessageType_name {
 		s := NewTestLogDB()
-		rawNode := Launch(newTestConfig(1, 10, 1, s), s, nil, []PeerAddress{{NodeID: 1}}, true, true)
+		rawNode := Launch(newTestConfig(1, 10, 1), s, nil, []PeerAddress{{NodeID: 1}}, true, true)
 		rawNode.raft.hasNotAppliedConfigChange = rawNode.raft.testOnlyHasConfigChangeToApply
 
 		msgt := pb.MessageType(i)
@@ -74,13 +74,13 @@ func TestRaftAPINodeStep(t *testing.T) {
 
 func TestRaftAPIRequestLeaderTransfer(t *testing.T) {
 	s := NewTestLogDB()
-	p := Launch(newTestConfig(1, 10, 1, s), s, nil, []PeerAddress{{NodeID: 1}}, true, true)
+	p := Launch(newTestConfig(1, 10, 1), s, nil, []PeerAddress{{NodeID: 1}}, true, true)
 	p.RequestLeaderTransfer(1)
 }
 
 func TestRaftAPIRTT(t *testing.T) {
 	s := NewTestLogDB()
-	p := Launch(newTestConfig(1, 10, 1, s), s, nil, []PeerAddress{{NodeID: 1}}, true, true)
+	p := Launch(newTestConfig(1, 10, 1), s, nil, []PeerAddress{{NodeID: 1}}, true, true)
 	tick := p.raft.electionTick
 	p.Tick()
 	if p.raft.electionTick != tick+1 {
@@ -94,7 +94,7 @@ func TestRaftAPIRTT(t *testing.T) {
 
 func TestRaftAPIReportUnreachable(t *testing.T) {
 	s := NewTestLogDB()
-	p := Launch(newTestConfig(1, 10, 1, s), s, nil, []PeerAddress{
+	p := Launch(newTestConfig(1, 10, 1), s, nil, []PeerAddress{
 		{NodeID: 1, Address: "1"},
 		{NodeID: 2, Address: "2"},
 	}, true, true)
@@ -111,7 +111,7 @@ func TestRaftAPIReportUnreachable(t *testing.T) {
 
 func TestRaftAPIReportSnapshotStatus(t *testing.T) {
 	s := NewTestLogDB()
-	p := Launch(newTestConfig(1, 10, 1, s), s, nil, []PeerAddress{
+	p := Launch(newTestConfig(1, 10, 1), s, nil, []PeerAddress{
 		{NodeID: 1, Address: "1"},
 		{NodeID: 2, Address: "2"},
 	}, true, true)
@@ -129,7 +129,7 @@ func TestRaftAPIReportSnapshotStatus(t *testing.T) {
 func testRaftAPIProposeAndConfigChange(cct pb.ConfigChangeType, nid uint64, t *testing.T) {
 	s := NewTestLogDB()
 	var err error
-	rawNode := Launch(newTestConfig(1, 10, 1, s), s, nil, []PeerAddress{{NodeID: 1}}, true, true)
+	rawNode := Launch(newTestConfig(1, 10, 1), s, nil, []PeerAddress{{NodeID: 1}}, true, true)
 	rawNode.raft.hasNotAppliedConfigChange = rawNode.raft.testOnlyHasConfigChangeToApply
 	ud := rawNode.GetUpdate(true, 0)
 	if err := s.Append(ud.EntriesToSave); err != nil {
@@ -200,7 +200,7 @@ func TestRaftAPIProposeAndConfigChange(t *testing.T) {
 
 func TestGetUpdateIncludeLastAppliedValue(t *testing.T) {
 	s := NewTestLogDB()
-	rawNode := Launch(newTestConfig(1, 10, 1, s), s, nil, []PeerAddress{{NodeID: 1}}, true, true)
+	rawNode := Launch(newTestConfig(1, 10, 1), s, nil, []PeerAddress{{NodeID: 1}}, true, true)
 	ud := rawNode.GetUpdate(true, 1232)
 	if ud.LastApplied != 1232 {
 		t.Errorf("unexpected last applied value %d, want 1232", ud.LastApplied)
@@ -213,7 +213,7 @@ func TestGetUpdateIncludeLastAppliedValue(t *testing.T) {
 
 func TestRaftMoreEntriesToApplyControl(t *testing.T) {
 	s := NewTestLogDB()
-	rawNode := Launch(newTestConfig(1, 10, 1, s), s, nil, []PeerAddress{{NodeID: 1}}, true, true)
+	rawNode := Launch(newTestConfig(1, 10, 1), s, nil, []PeerAddress{{NodeID: 1}}, true, true)
 	rawNode.raft.hasNotAppliedConfigChange = rawNode.raft.testOnlyHasConfigChangeToApply
 	ud := rawNode.GetUpdate(true, 0)
 	if err := s.Append(ud.EntriesToSave); err != nil {
@@ -250,7 +250,7 @@ func TestRaftMoreEntriesToApplyControl(t *testing.T) {
 
 func TestRaftAPIProposeAddDuplicateNode(t *testing.T) {
 	s := NewTestLogDB()
-	rawNode := Launch(newTestConfig(1, 10, 1, s), s, nil, []PeerAddress{{NodeID: 1}}, true, true)
+	rawNode := Launch(newTestConfig(1, 10, 1), s, nil, []PeerAddress{{NodeID: 1}}, true, true)
 	rawNode.raft.hasNotAppliedConfigChange = rawNode.raft.testOnlyHasConfigChangeToApply
 	ud := rawNode.GetUpdate(true, 0)
 	if err := s.Append(ud.EntriesToSave); err != nil {
@@ -333,7 +333,7 @@ func TestRaftAPIProposeAddDuplicateNode(t *testing.T) {
 
 func TestRaftAPIRejectConfigChange(t *testing.T) {
 	s := NewTestLogDB()
-	p := Launch(newTestConfig(1, 10, 1, s), s, nil, []PeerAddress{{NodeID: 1}}, true, true)
+	p := Launch(newTestConfig(1, 10, 1), s, nil, []PeerAddress{{NodeID: 1}}, true, true)
 	p.raft.setPendingConfigChange()
 	if !p.raft.hasPendingConfigChange() {
 		t.Errorf("pending config change flag not set")
@@ -346,7 +346,7 @@ func TestRaftAPIRejectConfigChange(t *testing.T) {
 
 func TestRaftAPINotifyRaftLastApplied(t *testing.T) {
 	s := NewTestLogDB()
-	p := Launch(newTestConfig(1, 10, 1, s), s, nil, []PeerAddress{{NodeID: 1}}, true, true)
+	p := Launch(newTestConfig(1, 10, 1), s, nil, []PeerAddress{{NodeID: 1}}, true, true)
 	p.NotifyRaftLastApplied(123)
 	if p.raft.getApplied() != 123 {
 		t.Errorf("applied not set")
@@ -355,7 +355,7 @@ func TestRaftAPINotifyRaftLastApplied(t *testing.T) {
 
 func TestRaftAPIDumpRaftInfoToLog(t *testing.T) {
 	s := NewTestLogDB()
-	p := Launch(newTestConfig(1, 10, 1, s),
+	p := Launch(newTestConfig(1, 10, 1),
 		s, nil, []PeerAddress{{NodeID: 1, Address: "1"}}, true, true)
 	m := make(map[uint64]string)
 	m[1] = "1"
@@ -370,7 +370,7 @@ func TestRaftAPIReadIndex(t *testing.T) {
 	wrs := []pb.ReadyToRead{{Index: uint64(1), SystemCtx: getTestSystemCtx(12345)}}
 
 	s := NewTestLogDB()
-	c := newTestConfig(1, 10, 1, s)
+	c := newTestConfig(1, 10, 1)
 	rawNode := Launch(c, s, nil, []PeerAddress{{NodeID: 1}}, true, true)
 	rawNode.raft.hasNotAppliedConfigChange = rawNode.raft.testOnlyHasConfigChangeToApply
 	rawNode.raft.readyToRead = wrs
@@ -422,7 +422,7 @@ func TestRaftAPIReadIndex(t *testing.T) {
 
 func TestRaftAPIStatus(t *testing.T) {
 	storage := NewTestLogDB()
-	rawNode := Launch(newTestConfig(1, 10, 1, storage), storage, nil, []PeerAddress{{NodeID: 1}}, true, true)
+	rawNode := Launch(newTestConfig(1, 10, 1), storage, nil, []PeerAddress{{NodeID: 1}}, true, true)
 	rawNode.raft.hasNotAppliedConfigChange = rawNode.raft.testOnlyHasConfigChangeToApply
 	status := getLocalStatus(rawNode.raft)
 	if status.NodeID != 1 {
@@ -449,7 +449,7 @@ func TestRaftAPIInvalidInputToLaunchCausePanic(t *testing.T) {
 		t.Errorf("panic not called")
 	}()
 	storage := NewTestLogDB()
-	Launch(newTestConfig(1, 10, 1, storage), storage, nil, []PeerAddress{}, true, true)
+	Launch(newTestConfig(1, 10, 1), storage, nil, []PeerAddress{}, true, true)
 }
 
 func TestRaftAPIDuplicatedAddressCausePanicInLaunch(t *testing.T) {
@@ -460,7 +460,7 @@ func TestRaftAPIDuplicatedAddressCausePanicInLaunch(t *testing.T) {
 		t.Errorf("panic not called")
 	}()
 	storage := NewTestLogDB()
-	Launch(newTestConfig(1, 10, 1, storage), storage, nil, []PeerAddress{
+	Launch(newTestConfig(1, 10, 1), storage, nil, []PeerAddress{
 		{NodeID: 1, Address: "111"},
 		{NodeID: 2, Address: "111"},
 	}, true, true)
@@ -494,7 +494,7 @@ func TestRaftAPILaunch(t *testing.T) {
 	}
 
 	storage := NewTestLogDB()
-	rawNode := Launch(newTestConfig(1, 10, 1, storage), storage, nil, []PeerAddress{{NodeID: 1}}, true, true)
+	rawNode := Launch(newTestConfig(1, 10, 1), storage, nil, []PeerAddress{{NodeID: 1}}, true, true)
 	rawNode.raft.hasNotAppliedConfigChange = rawNode.raft.testOnlyHasConfigChangeToApply
 	ud := rawNode.GetUpdate(true, 0)
 	ud.Messages = nil
@@ -556,7 +556,7 @@ func TestRaftAPIRestart(t *testing.T) {
 	if err := storage.Append(entries); err != nil {
 		t.Fatalf("%v", err)
 	}
-	rawNode := Launch(newTestConfig(1, 10, 1, storage), storage, nil, nil, true, false)
+	rawNode := Launch(newTestConfig(1, 10, 1), storage, nil, nil, true, false)
 	rawNode.raft.hasNotAppliedConfigChange = rawNode.raft.testOnlyHasConfigChangeToApply
 	ud := rawNode.GetUpdate(true, 0)
 	ud.Messages = nil
@@ -597,7 +597,7 @@ func TestRaftAPIRestartFromSnapshot(t *testing.T) {
 	if err := s.Append(entries); err != nil {
 		t.Fatalf("%v", err)
 	}
-	rawNode := Launch(newTestConfig(1, 10, 1, s), s, nil, nil, true, false)
+	rawNode := Launch(newTestConfig(1, 10, 1), s, nil, nil, true, false)
 	rawNode.raft.hasNotAppliedConfigChange = rawNode.raft.testOnlyHasConfigChangeToApply
 	ud := rawNode.GetUpdate(true, 0)
 	ud.Messages = nil
@@ -619,7 +619,7 @@ func TestRaftAPIStepOnLocalMessageWillPanic(t *testing.T) {
 		t.Errorf("panic not triggered")
 	}()
 	storage := NewTestLogDB()
-	p := Launch(newTestConfig(1, 10, 1, storage), storage, nil, []PeerAddress{{NodeID: 1}}, true, true)
+	p := Launch(newTestConfig(1, 10, 1), storage, nil, []PeerAddress{{NodeID: 1}}, true, true)
 	p.Handle(pb.Message{Type: pb.LocalTick})
 }
 

--- a/internal/raft/raft.go
+++ b/internal/raft/raft.go
@@ -486,7 +486,7 @@ func (r *raft) restoreRemotes(ss pb.Snapshot) {
 		if id == r.nodeID && r.state == observer {
 			r.becomeFollower(r.term, r.leaderID)
 		}
-		_, ok = r.witnesses[id]
+		_, ok := r.witnesses[id]
 		if ok {
 			plog.Panicf("Assumed witness could not promote to full member")
 		}

--- a/internal/raft/raft.go
+++ b/internal/raft/raft.go
@@ -431,18 +431,6 @@ func (r *raft) votingMembers() map[uint64]*remote {
 	return nodes
 }
 
-func (r *raft) sortedVotingMemberIds() []uint64 {
-	nodes := r.votingMembers()
-
-	ids := make([]uint64, 0)
-	for id := range nodes {
-		ids = append(ids, id)
-	}
-
-	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
-	return ids
-}
-
 func (r *raft) raftState() pb.State {
 	return pb.State{
 		Term:   r.term,
@@ -1109,7 +1097,7 @@ func (r *raft) campaign() {
 		r.isLeaderTransferTarget = false
 	}
 
-	for _, k := range r.sortedVotingMemberIds() {
+	for k := range r.votingMembers() {
 		if k == r.nodeID {
 			continue
 		}

--- a/internal/raft/raft.go
+++ b/internal/raft/raft.go
@@ -65,6 +65,7 @@ const (
 	candidate
 	leader
 	observer
+	witness
 	numStates
 )
 
@@ -73,6 +74,7 @@ var stateNames = [...]string{
 	"Candidate",
 	"Leader",
 	"Observer",
+	"Witness",
 }
 
 func (st State) String() string {
@@ -137,6 +139,7 @@ func getLocalStatus(r *raft) Status {
 //  * ReadIndex protocol for read-only queries
 //  * leadership transfer
 //  * non-voting members
+//  * witness members
 //  * idempotent updates
 //  * quorum check
 //  * batching
@@ -200,6 +203,7 @@ type raft struct {
 	rl                        *server.RateLimiter
 	remotes                   map[uint64]*remote
 	observers                 map[uint64]*remote
+	witnesses                 map[uint64]*remote
 	state                     State
 	votes                     map[uint64]bool
 	msgs                      []pb.Message
@@ -230,10 +234,14 @@ func newRaft(c *config.Config, logdb ILogDB) *raft {
 	if err := c.Validate(); err != nil {
 		panic(err)
 	}
-	if logdb == nil {
+
+	// All nodes except witness should have logdb initialized.
+	if logdb == nil && !c.IsWitness {
 		panic("logdb is nil")
 	}
+
 	rl := server.NewRateLimiter(c.MaxInMemLogSize)
+
 	r := &raft{
 		clusterID:        c.ClusterID,
 		nodeID:           c.NodeID,
@@ -243,36 +251,53 @@ func newRaft(c *config.Config, logdb ILogDB) *raft {
 		log:              newEntryLog(logdb, rl),
 		remotes:          make(map[uint64]*remote),
 		observers:        make(map[uint64]*remote),
+		witnesses:        make(map[uint64]*remote),
 		electionTimeout:  c.ElectionRTT,
 		heartbeatTimeout: c.HeartbeatRTT,
 		checkQuorum:      c.CheckQuorum,
 		readIndex:        newReadIndex(),
 		rl:               rl,
 	}
+
 	plog.Infof("%s raft log rate limit enabled: %t, %d",
 		dn(r.clusterID, r.nodeID), r.rl.Enabled(), c.MaxInMemLogSize)
-	st, members := logdb.NodeState()
-	for p := range members.Addresses {
-		r.remotes[p] = &remote{
-			next: 1,
+
+	if logdb != nil {
+		st, members := logdb.NodeState()
+		for p := range members.Addresses {
+			r.remotes[p] = &remote{
+				next: 1,
+			}
+		}
+		for p := range members.Observers {
+			r.observers[p] = &remote{
+				next: 1,
+			}
+		}
+		for p := range members.Witnesses {
+			r.witnesses[p] = &remote{
+				next: 1,
+			}
+		}
+
+		r.resetMatchValueArray()
+		if !pb.IsEmptyState(st) {
+			r.loadState(st)
 		}
 	}
-	for p := range members.Observers {
-		r.observers[p] = &remote{
-			next: 1,
-		}
-	}
-	r.resetMatchValueArray()
-	if !pb.IsEmptyState(st) {
-		r.loadState(st)
-	}
+
+	// Set node initial state.
 	if c.IsObserver {
 		r.state = observer
 		r.becomeObserver(r.term, NoLeader)
+	} else if c.IsWitness {
+		r.state = witness
+		r.becomeWitness(r.term, NoLeader)
 	} else {
 		// see first paragraph section 5.2 of the raft paper
 		r.becomeFollower(r.term, NoLeader)
 	}
+
 	r.initializeHandlerMap()
 	r.checkHandlerMap()
 	r.handle = defaultHandle
@@ -296,7 +321,7 @@ func (r *raft) getApplied() uint64 {
 }
 
 func (r *raft) resetMatchValueArray() {
-	r.matched = make([]uint64, len(r.remotes))
+	r.matched = make([]uint64, r.votingMemberCt())
 }
 
 func (r *raft) describe() string {
@@ -313,6 +338,10 @@ func (r *raft) describe() string {
 
 func (r *raft) isObserver() bool {
 	return r.state == observer
+}
+
+func (r *raft) isWitness() bool {
+	return r.state == witness
 }
 
 func (r *raft) mustBeLeader() {
@@ -342,8 +371,12 @@ func (r *raft) abortLeaderTransfer() {
 	r.leaderTransferTarget = NoNode
 }
 
+func (r *raft) votingMemberCt() int {
+	return len(r.remotes) + len(r.witnesses)
+}
+
 func (r *raft) quorum() int {
-	return len(r.remotes)/2 + 1
+	return r.votingMemberCt()/2 + 1
 }
 
 func (r *raft) isSingleNodeQuorum() bool {
@@ -352,25 +385,62 @@ func (r *raft) isSingleNodeQuorum() bool {
 
 func (r *raft) leaderHasQuorum() bool {
 	c := 0
-	for nid := range r.remotes {
-		if nid == r.nodeID || r.remotes[nid].isActive() {
+
+	for nid := range r.votingMembers() {
+		shouldCt := nid == r.nodeID
+		if rp, rok := r.remotes[nid]; rok && rp.isActive() {
+			shouldCt = true
+			rp.setNotActive()
+		}
+
+		if wp, wok := r.witnesses[nid]; wok && wp.isActive() {
+			shouldCt = true
+			wp.setNotActive()
+		}
+
+		if shouldCt {
 			c++
-			r.remotes[nid].setNotActive()
 		}
 	}
 	return c >= r.quorum()
 }
 
 func (r *raft) nodes() []uint64 {
-	nodes := make([]uint64, 0, len(r.remotes)+len(r.observers))
+	nodes := make([]uint64, 0, r.votingMemberCt()+len(r.observers))
 	for id := range r.remotes {
 		nodes = append(nodes, id)
 	}
 	for id := range r.observers {
 		nodes = append(nodes, id)
 	}
+	for id := range r.witnesses {
+		nodes = append(nodes, id)
+	}
 	sort.Slice(nodes, func(i, j int) bool { return nodes[i] < nodes[j] })
 	return nodes
+}
+
+func (r *raft) votingMembers() map[uint64]*remote {
+	nodes := make(map[uint64]*remote, r.votingMemberCt())
+	for id, rm := range r.remotes {
+		nodes[id] = rm
+	}
+	for id, wt := range r.witnesses {
+		nodes[id] = wt
+	}
+	return nodes
+}
+
+func (r *raft) sortedVotingMemberIds() []uint64 {
+	nodes := r.votingMembers()
+
+	ids := make([]uint64, 0)
+	for id := range nodes {
+		ids = append(ids, id)
+	}
+
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
 }
 
 func (r *raft) raftState() pb.State {
@@ -404,6 +474,16 @@ func (r *raft) restore(ss pb.Snapshot) bool {
 			}
 		}
 	}
+
+	if !r.isWitness() {
+		for nid := range ss.Membership.Witnesses {
+			if nid == r.nodeID {
+				plog.Panicf("%s converting to witness, index %d, committed %d, %+v",
+					r.describe(), ss.Index, r.log.committed, ss)
+			}
+		}
+	}
+
 	// p52 of the raft thesis
 	if r.log.matchTerm(ss.Index, ss.Term) {
 		// a snapshot at index X implies that X has been committed
@@ -422,6 +502,11 @@ func (r *raft) restoreRemotes(ss pb.Snapshot) {
 		if id == r.nodeID && r.state == observer {
 			r.becomeFollower(r.term, r.leaderID)
 		}
+		_, ok = r.witnesses[id]
+		if ok {
+			r.becomeFollower(r.term, r.leaderID)
+		}
+
 		match := uint64(0)
 		next := r.log.lastIndex() + 1
 		if id == r.nodeID {
@@ -444,6 +529,17 @@ func (r *raft) restoreRemotes(ss pb.Snapshot) {
 		r.setObserver(id, match, next)
 		plog.Infof("%s restored observer progress of %s [%s]",
 			r.describe(), NodeID(id), r.observers[id])
+	}
+
+	for id := range ss.Membership.Witnesses {
+		match := uint64(0)
+		next := r.log.lastIndex() + 1
+		if id == r.nodeID {
+			match = next - 1
+		}
+		r.setWitness(id, match, next)
+		plog.Infof("%s restored witness progress of %s [%s]",
+			r.describe(), NodeID(id), r.witnesses[id])
 	}
 	r.resetMatchValueArray()
 }
@@ -507,8 +603,8 @@ func (r *raft) nonLeaderTick() {
 		}
 	}
 	// section 4.2.1 of the raft thesis
-	// non-voting member is not to do anything related to election
-	if r.isObserver() {
+	// non-voting member or witness will not participate in election
+	if r.isObserver() || r.isWitness() {
 		return
 	}
 	// 6th paragraph section 5.2 of the raft paper
@@ -630,10 +726,12 @@ func (r *raft) makeReplicateMessage(to uint64,
 	if err != nil {
 		return pb.Message{}, err
 	}
+
 	entries, err := r.log.entries(next, maxSize)
 	if err != nil {
 		return pb.Message{}, err
 	}
+
 	if len(entries) > 0 {
 		lastIndex := entries[len(entries)-1].Index
 		expected := next - 1 + uint64(len(entries))
@@ -642,6 +740,17 @@ func (r *raft) makeReplicateMessage(to uint64,
 				r.describe(), expected, lastIndex)
 		}
 	}
+	// Don't send actual log entry to witness as they won't replicate real message,
+	// unless there is a config change.
+	if r.isWitness() {
+		for _, entry := range entries {
+			if entry.Type == pb.ApplicationEntry {
+				entry.Cmd = nil
+			}
+			entry.Type = pb.MetadataEntry
+		}
+	}
+
 	return pb.Message{
 		To:       to,
 		Type:     pb.Replicate,
@@ -656,12 +765,15 @@ func (r *raft) sendReplicateMessage(to uint64) {
 	var rp *remote
 	if v, ok := r.remotes[to]; ok {
 		rp = v
+	} else if v, ok := r.observers[to]; ok {
+		rp = v
 	} else {
-		rp, ok = r.observers[to]
+		rp, ok = r.witnesses[to]
 		if !ok {
 			plog.Panicf("%s failed to get the remote instance", r.describe())
 		}
 	}
+
 	if rp.isPaused() {
 		return
 	}
@@ -701,16 +813,16 @@ func (r *raft) broadcastReplicateMessage() {
 		}
 		r.sendReplicateMessage(nid)
 	}
+	for nid := range r.witnesses {
+		if nid == r.nodeID {
+			panic("witness is trying to broadcast Replicate msg")
+		}
+		r.sendReplicateMessage(nid)
+	}
 }
 
 func (r *raft) sendHeartbeatMessage(to uint64,
-	hint pb.SystemCtx, toObserver bool) {
-	var match uint64
-	if toObserver {
-		match = r.observers[to].match
-	} else {
-		match = r.remotes[to].match
-	}
+	hint pb.SystemCtx, match uint64) {
 	commit := min(match, r.log.committed)
 	r.send(pb.Message{
 		To:       to,
@@ -735,14 +847,17 @@ func (r *raft) broadcastHeartbeatMessage() {
 
 func (r *raft) broadcastHeartbeatMessageWithHint(ctx pb.SystemCtx) {
 	zeroCtx := pb.SystemCtx{}
-	for id := range r.remotes {
+	for id, rm := range r.remotes {
 		if id != r.nodeID {
-			r.sendHeartbeatMessage(id, ctx, false)
+			r.sendHeartbeatMessage(id, ctx, rm.match)
 		}
 	}
 	if ctx == zeroCtx {
-		for id := range r.observers {
-			r.sendHeartbeatMessage(id, zeroCtx, true)
+		for id, rm := range r.observers {
+			r.sendHeartbeatMessage(id, zeroCtx, rm.match)
+		}
+		for id, rm := range r.witnesses {
+			r.sendHeartbeatMessage(id, zeroCtx, rm.match)
 		}
 	}
 }
@@ -787,16 +902,17 @@ func (r *raft) sortMatchValues() {
 
 func (r *raft) tryCommit() bool {
 	r.mustBeLeader()
-	if len(r.remotes) != len(r.matched) {
+	if r.votingMemberCt() != len(r.matched) {
 		r.resetMatchValueArray()
 	}
 	idx := 0
-	for _, v := range r.remotes {
+	for _, v := range r.votingMembers() {
 		r.matched[idx] = v.match
 		idx++
 	}
+
 	r.sortMatchValues()
-	q := r.matched[len(r.remotes)-r.quorum()]
+	q := r.matched[r.votingMemberCt()-r.quorum()]
 	// see p8 raft paper
 	// "Raft never commits log entries from previous terms by counting replicas.
 	// Only log entries from the leader’s current term are committed by counting
@@ -830,6 +946,15 @@ func (r *raft) becomeObserver(term uint64, leaderID uint64) {
 	plog.Infof("%s became an observer", r.describe())
 }
 
+func (r *raft) becomeWitness(term uint64, leaderID uint64) {
+	if r.state != witness {
+		panic("transitioning to witness state from non-witness")
+	}
+	r.reset(term)
+	r.setLeaderID(leaderID)
+	plog.Infof("%s became a witness", r.describe())
+}
+
 func (r *raft) becomeFollower(term uint64, leaderID uint64) {
 	r.state = follower
 	r.reset(term)
@@ -844,6 +969,10 @@ func (r *raft) becomeCandidate() {
 	if r.state == observer {
 		panic("observer is becoming candidate")
 	}
+	if r.state == witness {
+		panic("witness is becoming candidate")
+	}
+
 	r.state = candidate
 	// 2nd paragraph section 5.2 of the raft paper
 	r.reset(r.term + 1)
@@ -853,11 +982,9 @@ func (r *raft) becomeCandidate() {
 }
 
 func (r *raft) becomeLeader() {
-	if r.state == follower {
-		panic("transitioning to leader state from follower")
-	}
-	if r.state == observer {
-		panic("observer is become leader")
+	// need a state transition machine
+	if r.state != leader && r.state != candidate {
+		plog.Panicf("transitioning to leader state from %v", r.state.String())
 	}
 	r.state = leader
 	r.reset(r.term)
@@ -885,6 +1012,7 @@ func (r *raft) reset(term uint64) {
 	r.abortLeaderTransfer()
 	r.resetRemotes()
 	r.resetObservers()
+	r.resetWitnesses()
 	r.resetMatchValueArray()
 }
 
@@ -923,6 +1051,17 @@ func (r *raft) resetObservers() {
 	}
 }
 
+func (r *raft) resetWitnesses() {
+	for id := range r.witnesses {
+		r.witnesses[id] = &remote{
+			next: r.log.lastIndex() + 1,
+		}
+		if id == r.nodeID {
+			r.witnesses[id].match = r.log.lastIndex()
+		}
+	}
+}
+
 //
 // election related functions
 //
@@ -948,7 +1087,7 @@ func (r *raft) handleVoteResp(from uint64, rejected bool) int {
 }
 
 func (r *raft) campaign() {
-	plog.Infof("%s campaign called, remotes len: %d", r.describe(), len(r.remotes))
+	plog.Infof("%s campaign called, voting members len: %d", r.describe(), r.votingMemberCt())
 	r.becomeCandidate()
 	term := r.term
 	if r.events != nil {
@@ -969,7 +1108,8 @@ func (r *raft) campaign() {
 		hint = r.nodeID
 		r.isLeaderTransferTarget = false
 	}
-	for k := range r.remotes {
+
+	for _, k := range r.sortedVotingMemberIds() {
 		if k == r.nodeID {
 			continue
 		}
@@ -994,6 +1134,10 @@ func (r *raft) selfRemoved() bool {
 		_, ok := r.observers[r.nodeID]
 		return !ok
 	}
+	if r.state == witness {
+		_, ok := r.witnesses[r.nodeID]
+		return !ok
+	}
 	_, ok := r.remotes[r.nodeID]
 	return !ok
 }
@@ -1012,6 +1156,8 @@ func (r *raft) addNode(nodeID uint64) {
 		if nodeID == r.nodeID {
 			r.becomeFollower(r.term, r.leaderID)
 		}
+	} else if _, ok := r.witnesses[nodeID]; ok {
+		panic("could not promote witness to a full member")
 	} else {
 		r.setRemote(nodeID, 0, r.log.lastIndex()+1)
 	}
@@ -1025,9 +1171,18 @@ func (r *raft) addObserver(nodeID uint64) {
 	r.setObserver(nodeID, 0, r.log.lastIndex()+1)
 }
 
+func (r *raft) addWitness(nodeID uint64) {
+	r.clearPendingConfigChange()
+	if _, ok := r.witnesses[nodeID]; ok {
+		return
+	}
+	r.setWitness(nodeID, 0, r.log.lastIndex()+1)
+}
+
 func (r *raft) removeNode(nodeID uint64) {
 	r.deleteRemote(nodeID)
 	r.deleteObserver(nodeID)
+	r.deleteWitness(nodeID)
 	r.clearPendingConfigChange()
 	// step down as leader once it is removed
 	if r.nodeID == nodeID && r.state == leader {
@@ -1036,7 +1191,8 @@ func (r *raft) removeNode(nodeID uint64) {
 	if r.leaderTransfering() && r.leaderTransferTarget == nodeID {
 		r.abortLeaderTransfer()
 	}
-	if r.state == leader && len(r.remotes) > 0 {
+
+	if r.state == leader && r.votingMemberCt() > 0 {
 		if r.tryCommit() {
 			r.broadcastReplicateMessage()
 		}
@@ -1050,6 +1206,10 @@ func (r *raft) deleteRemote(nodeID uint64) {
 
 func (r *raft) deleteObserver(nodeID uint64) {
 	delete(r.observers, nodeID)
+}
+
+func (r *raft) deleteWitness(nodeID uint64) {
+	delete(r.witnesses, nodeID)
 }
 
 func (r *raft) setRemote(nodeID uint64, match uint64, next uint64) {
@@ -1066,6 +1226,15 @@ func (r *raft) setObserver(nodeID uint64, match uint64, next uint64) {
 	plog.Infof("%s set observer, id %s, match %d, next %d",
 		r.describe(), NodeID(nodeID), match, next)
 	r.observers[nodeID] = &remote{
+		next:  next,
+		match: match,
+	}
+}
+
+func (r *raft) setWitness(nodeID uint64, match uint64, next uint64) {
+	plog.Infof("%s set witness, id %s, match %d, next %d",
+		r.describe(), NodeID(nodeID), match, next)
+	r.witnesses[nodeID] = &remote{
 		next:  next,
 		match: match,
 	}
@@ -1135,6 +1304,7 @@ func (r *raft) getPendingConfigChangeCount() int {
 
 func (r *raft) handleHeartbeatMessage(m pb.Message) {
 	r.log.commitTo(m.Commit)
+
 	r.send(pb.Message{
 		To:       m.From,
 		Type:     pb.HeartbeatResp,
@@ -1261,6 +1431,8 @@ func (r *raft) onMessageTermNotMatched(m pb.Message) bool {
 
 		if r.isObserver() {
 			r.becomeObserver(m.Term, leaderID)
+		} else if r.isWitness() {
+			r.becomeWitness(m.Term, leaderID)
 		} else {
 			r.becomeFollower(m.Term, leaderID)
 		}
@@ -1317,7 +1489,7 @@ func (r *raft) handleNodeElection(m pb.Message) {
 		// available on X. If X is allowed to start a new election, it can become the
 		// leader with a vote from any one of the node Y or Z. Further proposals made
 		// by the new leader X in the next term will require a quorum of 2 which can
-		// has no overlap with the committed quorum of 3. this violates the safety
+		// have no overlap with the committed quorum of 3. this violates the safety
 		// requirement of raft.
 		// ignore the Election message when there is membership configure change
 		// committed but not applied
@@ -1377,6 +1549,8 @@ func (r *raft) handleNodeConfigChange(m pb.Message) {
 			r.removeNode(nodeid)
 		case pb.AddObserver:
 			r.addObserver(nodeid)
+		case pb.AddWitness:
+			r.addWitness(nodeid)
 		default:
 			panic("unexpected config change type")
 		}
@@ -1477,8 +1651,9 @@ func (r *raft) handleLeaderReadIndex(m pb.Message) {
 		r.broadcastHeartbeatMessageWithHint(ctx)
 	} else {
 		r.addReadyToRead(r.log.committed, ctx)
-		_, ok := r.observers[m.From]
-		if m.From != r.nodeID && ok {
+		_, ook := r.observers[m.From]
+		_, wok := r.witnesses[m.From]
+		if m.From != r.nodeID && (ook || wok) {
 			r.send(pb.Message{
 				To:       m.From,
 				Type:     pb.ReadIndexResp,
@@ -1642,6 +1817,34 @@ func (r *raft) handleObserverReadIndex(m pb.Message) {
 }
 
 func (r *raft) handleObserverReadIndexResp(m pb.Message) {
+	r.handleFollowerReadIndexResp(m)
+}
+
+//
+// message handlers used by witness, re-route them to follower handlers
+//
+
+func (r *raft) handleWitnessReplicate(m pb.Message) {
+	r.handleFollowerReplicate(m)
+}
+
+func (r *raft) handleWitnessHeartbeat(m pb.Message) {
+	r.handleFollowerHeartbeat(m)
+}
+
+func (r *raft) handleWitnessSnapshot(m pb.Message) {
+	r.handleFollowerInstallSnapshot(m)
+}
+
+func (r *raft) handleWitnessPropose(m pb.Message) {
+	r.handleFollowerPropose(m)
+}
+
+func (r *raft) handleWitnessReadIndex(m pb.Message) {
+	r.handleFollowerReadIndex(m)
+}
+
+func (r *raft) handleWitnessReadIndexResp(m pb.Message) {
 	r.handleFollowerReadIndexResp(m)
 }
 
@@ -1824,6 +2027,8 @@ func lw(r *raft, f func(m pb.Message, rp *remote)) handlerFunc {
 			f(nm, npr)
 		} else if nob, ok := r.observers[nm.From]; ok {
 			f(nm, nob)
+		} else if wob, ok := r.witnesses[nm.From]; ok {
+			f(nm, wob)
 		} else {
 			plog.Infof("%s no remote for %s", r.describe(), NodeID(nm.From))
 			return
@@ -1892,6 +2097,18 @@ func (r *raft) initializeHandlerMap() {
 	r.handlers[observer][pb.ConfigChangeEvent] = r.handleNodeConfigChange
 	r.handlers[observer][pb.LocalTick] = r.handleLocalTick
 	r.handlers[observer][pb.SnapshotReceived] = r.handleRestoreRemote
+	// witness
+	r.handlers[witness][pb.Heartbeat] = r.handleWitnessHeartbeat
+	r.handlers[witness][pb.Replicate] = r.handleWitnessReplicate
+	r.handlers[witness][pb.InstallSnapshot] = r.handleWitnessSnapshot
+	r.handlers[witness][pb.Propose] = r.handleWitnessPropose
+	r.handlers[witness][pb.ReadIndex] = r.handleWitnessReadIndex
+	r.handlers[witness][pb.ReadIndexResp] = r.handleWitnessReadIndexResp
+	r.handlers[witness][pb.RequestVote] = r.handleNodeRequestVote
+	r.handlers[witness][pb.ConfigChangeEvent] = r.handleNodeConfigChange
+	r.handlers[witness][pb.LocalTick] = r.handleLocalTick
+	r.handlers[witness][pb.SnapshotReceived] = r.handleRestoreRemote
+
 }
 
 func (r *raft) checkHandlerMap() {
@@ -1917,6 +2134,10 @@ func (r *raft) checkHandlerMap() {
 		{observer, pb.RequestVoteResp},
 		{observer, pb.ReplicateResp},
 		{observer, pb.HeartbeatResp},
+		{witness, pb.Election},
+		{witness, pb.RequestVoteResp},
+		{witness, pb.ReplicateResp},
+		{witness, pb.HeartbeatResp},
 	}
 	for _, tt := range checks {
 		f := r.handlers[tt.stateType][tt.msgType]
@@ -1929,7 +2150,6 @@ func (r *raft) checkHandlerMap() {
 //
 // debugging related functions
 //
-
 func (r *raft) dumpRaftInfoToLog(addrMap map[uint64]string) {
 	var flag string
 	if r.leaderID != NoLeader && r.leaderID == r.nodeID {

--- a/internal/raft/raft_etcd_test.go
+++ b/internal/raft/raft_etcd_test.go
@@ -23,7 +23,6 @@ package raft
 import (
 	"bytes"
 	"fmt"
-	config2 "github.com/lni/dragonboat/config"
 	"io"
 	"io/ioutil"
 	"math"
@@ -2979,11 +2978,11 @@ func setRandomizedElectionTimeout(r *raft, v uint64) {
 	r.randomizedElectionTimeout = v
 }
 
-func newTestConfig(id uint64, election, heartbeat int) *config2.Config {
+func newTestConfig(id uint64, election, heartbeat int) *config.Config {
 	return newRateLimitedTestConfig(id, election, heartbeat, 0)
 }
 
-func newRateLimitedTestConfig(id uint64, election, heartbeat int, maxLogSize int) *config2.Config {
+func newRateLimitedTestConfig(id uint64, election, heartbeat int, maxLogSize int) *config.Config {
 	return &config.Config{
 		NodeID:       id,
 		ElectionRTT:  uint64(election),

--- a/internal/raft/raft_etcd_test.go
+++ b/internal/raft/raft_etcd_test.go
@@ -3041,10 +3041,10 @@ func newTestObserver(id uint64, peers []uint64, observers []uint64, election, he
 	return r
 }
 
-func newTestWitness(id uint64, peers []uint64, witnesses []uint64, election, heartbeat int) *raft {
-	cfg := newTestConfig(id, election, heartbeat, nil)
+func newTestWitness(id uint64, peers []uint64, witnesses []uint64, election, heartbeat int, logdb ILogDB) *raft {
+	cfg := newTestConfig(id, election, heartbeat, logdb)
 	cfg.IsWitness = true
-	r := newRaft(cfg, nil)
+	r := newRaft(cfg, logdb)
 	if len(r.remotes) == 0 {
 		for _, p := range peers {
 			r.remotes[p] = &remote{next: 1}

--- a/internal/raft/raft_etcd_test.go
+++ b/internal/raft/raft_etcd_test.go
@@ -23,6 +23,7 @@ package raft
 import (
 	"bytes"
 	"fmt"
+	config2 "github.com/lni/dragonboat/config"
 	"io"
 	"io/ioutil"
 	"math"
@@ -234,7 +235,7 @@ func TestLeaderTransferAfterSnapshot(t *testing.T) {
 	nt.send(pb.Message{From: 1, To: 1, Type: pb.Propose, Entries: []pb.Entry{{}}})
 	lead := nt.peers[1].(*raft)
 	nextEnts(lead, nt.storage[1])
-	m := getTestMembership(lead.nodes())
+	m := getTestMembership(lead.nodesSorted())
 	ss, err := nt.storage[1].(*TestLogDB).getSnapshot(lead.log.processed, &m)
 	if err != nil {
 		t.Fatalf("failed to get snapshot")
@@ -2251,12 +2252,12 @@ func TestRestore(t *testing.T) {
 		t.Errorf("log.lastTerm = %d, want %d", mustTerm(sm.log.term(s.Index)), s.Term)
 	}
 
-	if sliceEqual(sm.nodes(), getNodesFromMembership(s.Membership)) {
-		t.Errorf("snapshot remotes info restored too earlier: %v", sm.nodes())
+	if sliceEqual(sm.nodesSorted(), getNodesFromMembership(s.Membership)) {
+		t.Errorf("snapshot remotes info restored too earlier: %v", sm.nodesSorted())
 	}
 
 	sm.restoreRemotes(s)
-	sg := sm.nodes()
+	sg := sm.nodesSorted()
 	if !sliceEqual(sg, getNodesFromMembership(s.Membership)) {
 		t.Errorf("sm.Nodes = %+v, want %+v", sg, getNodesFromMembership(s.Membership))
 	}
@@ -2386,7 +2387,7 @@ func TestSlowNodeRestore(t *testing.T) {
 	}
 	lead := nt.peers[1].(*raft)
 	nextEnts(lead, nt.storage[1])
-	m := getTestMembership(lead.nodes())
+	m := getTestMembership(lead.nodesSorted())
 	ss, err := nt.storage[1].(*TestLogDB).getSnapshot(lead.log.processed, &m)
 	if err != nil {
 		t.Fatalf("failed to get snapshot")
@@ -2505,7 +2506,7 @@ func TestAddNode(t *testing.T) {
 	if r.pendingConfigChange {
 		t.Errorf("pendingConfigChange = %v, want false", r.pendingConfigChange)
 	}
-	nodes := r.nodes()
+	nodes := r.nodesSorted()
 	wnodes := []uint64{1, 2}
 	if !reflect.DeepEqual(nodes, wnodes) {
 		t.Errorf("nodes = %v, want %v", nodes, wnodes)
@@ -2522,14 +2523,14 @@ func TestRemoveNode(t *testing.T) {
 		t.Errorf("pendingConfigChange = %v, want false", r.pendingConfigChange)
 	}
 	w := []uint64{1}
-	if g := r.nodes(); !reflect.DeepEqual(g, w) {
+	if g := r.nodesSorted(); !reflect.DeepEqual(g, w) {
 		t.Errorf("nodes = %v, want %v", g, w)
 	}
 
 	// remove all nodes from cluster
 	r.removeNode(1)
 	w = []uint64{}
-	if g := r.nodes(); !reflect.DeepEqual(g, w) {
+	if g := r.nodesSorted(); !reflect.DeepEqual(g, w) {
 		t.Errorf("nodes = %v, want %v", g, w)
 	}
 }
@@ -2571,8 +2572,8 @@ func TestRaftNodes(t *testing.T) {
 	}
 	for i, tt := range tests {
 		r := newTestRaft(1, tt.ids, 10, 1, NewTestLogDB())
-		if !reflect.DeepEqual(r.nodes(), tt.wids) {
-			t.Errorf("#%d: nodes = %+v, want %+v", i, r.nodes(), tt.wids)
+		if !reflect.DeepEqual(r.nodesSorted(), tt.wids) {
+			t.Errorf("#%d: nodes = %+v, want %+v", i, r.nodesSorted(), tt.wids)
 		}
 	}
 }
@@ -2584,7 +2585,7 @@ func TestCampaignWhileLeader(t *testing.T) {
 func testCampaignWhileLeader(t *testing.T) {
 	s := NewTestLogDB()
 	peers := []uint64{1}
-	cfg := newTestConfig(1, 5, 1, s)
+	cfg := newTestConfig(1, 5, 1)
 	r := newRaft(cfg, s)
 	r.setTestPeers(peers)
 	if r.state != follower {
@@ -2794,7 +2795,7 @@ func entsWithConfig(configFunc func(*config.Config), terms ...uint64) *raft {
 			panic(err)
 		}
 	}
-	cfg := newTestConfig(1, 5, 1, storage)
+	cfg := newTestConfig(1, 5, 1)
 	if configFunc != nil {
 		configFunc(cfg)
 	}
@@ -2809,7 +2810,7 @@ func entsWithConfig(configFunc func(*config.Config), terms ...uint64) *raft {
 func votedWithConfig(configFunc func(*config.Config), vote, term uint64) *raft {
 	storage := NewTestLogDB()
 	storage.SetState(pb.State{Vote: vote, Term: term})
-	cfg := newTestConfig(1, 5, 1, storage)
+	cfg := newTestConfig(1, 5, 1)
 	if configFunc != nil {
 		configFunc(cfg)
 	}
@@ -2847,7 +2848,7 @@ func newNetworkWithConfig(configFunc func(*config.Config), peers ...stateMachine
 		switch v := p.(type) {
 		case nil:
 			nstorage[id] = NewTestLogDB()
-			cfg := newTestConfig(id, 10, 1, nstorage[id])
+			cfg := newTestConfig(id, 10, 1)
 			if configFunc != nil {
 				configFunc(cfg)
 			}
@@ -2978,16 +2979,21 @@ func setRandomizedElectionTimeout(r *raft, v uint64) {
 	r.randomizedElectionTimeout = v
 }
 
-func newTestConfig(id uint64, election, heartbeat int, logdb ILogDB) *config.Config {
+func newTestConfig(id uint64, election, heartbeat int) *config2.Config {
+	return newRateLimitedTestConfig(id, election, heartbeat, 0)
+}
+
+func newRateLimitedTestConfig(id uint64, election, heartbeat int, maxLogSize int) *config2.Config {
 	return &config.Config{
 		NodeID:       id,
 		ElectionRTT:  uint64(election),
 		HeartbeatRTT: uint64(heartbeat),
+		MaxInMemLogSize: uint64(maxLogSize),
 	}
 }
 
 func newTestRaft(id uint64, peers []uint64, election, heartbeat int, logdb ILogDB) *raft {
-	r := newRaft(newTestConfig(id, election, heartbeat, logdb), logdb)
+	r := newRaft(newTestConfig(id, election, heartbeat), logdb)
 	if len(r.remotes) == 0 {
 		for _, p := range peers {
 			r.remotes[p] = &remote{next: 1}
@@ -3024,7 +3030,7 @@ func newTestObserver(id uint64, peers []uint64, observers []uint64, election, he
 	if !found {
 		panic("observer node id not included in the observers list")
 	}
-	cfg := newTestConfig(id, election, heartbeat, logdb)
+	cfg := newTestConfig(id, election, heartbeat)
 	cfg.IsObserver = true
 	r := newRaft(cfg, logdb)
 	if len(r.remotes) == 0 {
@@ -3042,7 +3048,7 @@ func newTestObserver(id uint64, peers []uint64, observers []uint64, election, he
 }
 
 func newTestWitness(id uint64, peers []uint64, witnesses []uint64, election, heartbeat int, logdb ILogDB) *raft {
-	cfg := newTestConfig(id, election, heartbeat, logdb)
+	cfg := newTestConfig(id, election, heartbeat)
 	cfg.IsWitness = true
 	r := newRaft(cfg, logdb)
 	if len(r.remotes) == 0 {

--- a/internal/raft/raft_test.go
+++ b/internal/raft/raft_test.go
@@ -778,7 +778,7 @@ func TestNonWitnessWouldPanicWhenRemoteSnapshotAssumeAsWitness(t *testing.T) {
 		Term:       20,
 		Membership: members,
 	}
-	p1 := newTestObserver(1, []uint64{1}, []uint64{2}, 10, 1, NewTestLogDB())
+	p1 := newTestObserver(1, []uint64{1}, []uint64{1}, 10, 1, NewTestLogDB())
 	if !p1.isObserver() {
 		t.Errorf("not an observer")
 	}
@@ -789,6 +789,14 @@ func TestNonWitnessWouldPanicWhenRemoteSnapshotAssumeAsWitness(t *testing.T) {
 	if p1.isObserver() {
 		t.Errorf("observer not promoted")
 	}
+
+	p1.witnesses[2] = &remote{}
+	defer func() {
+		if r := recover(); r == nil {
+			panic("assumed witness not promotion not causing panic")
+		}
+	}()
+	p1.restoreRemotes(ss)
 }
 
 func TestWitnessReplication(t *testing.T) {

--- a/internal/raft/raft_test.go
+++ b/internal/raft/raft_test.go
@@ -634,7 +634,7 @@ func TestObserverCanBeRemoved(t *testing.T) {
 }
 
 func TestWitnessWillNotStartElection(t *testing.T) {
-	p := newTestWitness(1, nil, []uint64{1}, 10, 1)
+	p := newTestWitness(1, nil, []uint64{1}, 10, 1, NewTestLogDB())
 	if !p.isWitness() {
 		t.Errorf("not a witness")
 	}
@@ -651,7 +651,7 @@ func TestWitnessWillNotStartElection(t *testing.T) {
 }
 
 func TestWitnessWillVoteInElection(t *testing.T) {
-	p := newTestWitness(1, nil, []uint64{1}, 10, 1)
+	p := newTestWitness(1, nil, []uint64{1}, 10, 1, NewTestLogDB())
 	if !p.isWitness() {
 		t.Errorf("not a witness")
 	}
@@ -669,7 +669,7 @@ func TestWitnessCannotBePromotedToFullMember(t *testing.T) {
 	}()
 	nodeId := uint64(1)
 
-	p := newTestWitness(nodeId, nil, []uint64{1}, 10, 1)
+	p := newTestWitness(nodeId, nil, []uint64{1}, 10, 1, NewTestLogDB())
 	if !p.isWitness() {
 		t.Errorf("not an witness")
 	}
@@ -678,7 +678,7 @@ func TestWitnessCannotBePromotedToFullMember(t *testing.T) {
 
 func TestWitnessReplication(t *testing.T) {
 	p1 := newTestObserver(1, nil, []uint64{1}, 10, 1, NewTestLogDB())
-	p2 := newTestWitness(2, nil, []uint64{}, 10, 1)
+	p2 := newTestWitness(2, nil, []uint64{}, 10, 1, NewTestLogDB())
 	p1.addNode(1)
 	p1.addWitness(2)
 	p2.addNode(1)
@@ -717,7 +717,7 @@ func TestWitnessReplication(t *testing.T) {
 
 func TestWitnessCanPropose(t *testing.T) {
 	p1 := newTestRaft(1, []uint64{1, 2}, 10, 1, NewTestLogDB())
-	p2 := newTestWitness(2, nil, []uint64{2}, 10, 1)
+	p2 := newTestWitness(2, nil, []uint64{2}, 10, 1, NewTestLogDB())
 	p1.addWitness(2)
 	p2.addNode(1)
 	if !p2.isWitness() {
@@ -759,7 +759,7 @@ func TestWitnessCanPropose(t *testing.T) {
 func TestWitnessCanReadIndexQuorum2(t *testing.T) {
 	p1 := newTestRaft(1, []uint64{1, 2}, 10, 1, NewTestLogDB())
 	p2 := newTestRaft(2, []uint64{1, 2}, 10, 1, NewTestLogDB())
-	p3 := newTestWitness(3, nil, []uint64{3}, 10, 1)
+	p3 := newTestWitness(3, nil, []uint64{3}, 10, 1, NewTestLogDB())
 	p1.addWitness(3)
 	p2.addWitness(3)
 	p3.addNode(1)
@@ -809,7 +809,7 @@ func TestWitnessCanReceiveSnapshot(t *testing.T) {
 		Term:       20,
 		Membership: members,
 	}
-	p1 := newTestWitness(3, []uint64{1}, []uint64{2}, 10, 1)
+	p1 := newTestWitness(3, []uint64{1}, []uint64{2}, 10, 1, NewTestLogDB())
 	if !p1.isWitness() {
 		t.Errorf("not a witness")
 	}
@@ -820,7 +820,7 @@ func TestWitnessCanReceiveSnapshot(t *testing.T) {
 }
 
 func TestWitnessCanReceiveHeartbeatMessage(t *testing.T) {
-	p1 := newTestWitness(2, []uint64{1}, []uint64{2}, 10, 1)
+	p1 := newTestWitness(2, []uint64{1}, []uint64{2}, 10, 1, NewTestLogDB())
 	m := pb.Message{
 		From:     1,
 		To:       2,
@@ -868,7 +868,7 @@ func TestWitnessCanNotBeRestored(t *testing.T) {
 		Term:       20,
 		Membership: members,
 	}
-	p1 := newTestWitness(3, []uint64{1, 2}, []uint64{3}, 10, 1)
+	p1 := newTestWitness(3, []uint64{1, 2}, []uint64{3}, 10, 1, NewTestLogDB())
 	if ok := p1.restore(ss); !ok {
 		t.Errorf("failed to restore")
 	}
@@ -914,7 +914,7 @@ func TestWitnessCanBeAdded(t *testing.T) {
 }
 
 func TestWitnessCanBeRemoved(t *testing.T) {
-	p1 := newTestWitness(1, []uint64{1}, []uint64{2}, 10, 1)
+	p1 := newTestWitness(1, []uint64{1}, []uint64{2}, 10, 1, NewTestLogDB())
 	if len(p1.witnesses) != 1 {
 		t.Errorf("unexpected witness count")
 	}

--- a/internal/raft/raft_test.go
+++ b/internal/raft/raft_test.go
@@ -15,8 +15,8 @@
 package raft
 
 import (
-	"github.com/lni/dragonboat/config"
-	"github.com/lni/dragonboat/internal/settings"
+	"github.com/lni/dragonboat/v3/config"
+	"github.com/lni/dragonboat/v3/internal/settings"
 	"math"
 	"reflect"
 	"sort"

--- a/node.go
+++ b/node.go
@@ -883,12 +883,10 @@ func (n *node) processDroppedReadIndexes(ud pb.Update) {
 
 func (n *node) processDroppedEntries(ud pb.Update) {
 	for _, e := range ud.DroppedEntries {
-		if e.Type == pb.ApplicationEntry || e.Type == pb.EncodedEntry {
+		if e.Type == pb.ApplicationEntry || e.Type == pb.EncodedEntry || e.Type == pb.MetadataEntry {
 			n.pendingProposals.dropped(e.ClientID, e.SeriesID, e.Key)
 		} else if e.Type == pb.ConfigChangeEntry {
 			n.pendingConfigChange.dropped(e.Key)
-		} else if e.Type == pb.MetadataEntry {
-			// not applicable atm
 		} else {
 			plog.Panicf("unknown dropped entry type %s", e.Type)
 		}

--- a/node.go
+++ b/node.go
@@ -887,6 +887,8 @@ func (n *node) processDroppedEntries(ud pb.Update) {
 			n.pendingProposals.dropped(e.ClientID, e.SeriesID, e.Key)
 		} else if e.Type == pb.ConfigChangeEntry {
 			n.pendingConfigChange.dropped(e.Key)
+		} else if e.Type == pb.MetadataEntry {
+			// not applicable atm
 		} else {
 			plog.Panicf("unknown dropped entry type %s", e.Type)
 		}

--- a/nodehost.go
+++ b/nodehost.go
@@ -160,6 +160,8 @@ type ClusterInfo struct {
 	IsLeader bool
 	// IsObserver indicates whether this is a non-voting observer node.
 	IsObserver bool
+	// IsWitness indicates whether this is a witness node without actual log.
+	IsWitness bool
 	// StateMachineType is the type of the state machine.
 	StateMachineType sm.Type
 	// Nodes is a map of member node IDs to their Raft addresses.

--- a/raftpb/raft.pb.go
+++ b/raftpb/raft.pb.go
@@ -138,6 +138,7 @@ const (
 	ApplicationEntry  EntryType = 0
 	ConfigChangeEntry EntryType = 1
 	EncodedEntry      EntryType = 2
+	MetadataEntry     EntryType = 3
 )
 
 var EntryType_name = map[int32]string{
@@ -181,18 +182,21 @@ const (
 	AddNode     ConfigChangeType = 0
 	RemoveNode  ConfigChangeType = 1
 	AddObserver ConfigChangeType = 2
+	AddWitness  ConfigChangeType = 3
 )
 
 var ConfigChangeType_name = map[int32]string{
 	0: "AddNode",
 	1: "RemoveNode",
 	2: "AddObserver",
+	3: "AddWitness",
 }
 
 var ConfigChangeType_value = map[string]int32{
 	"AddNode":     0,
 	"RemoveNode":  1,
 	"AddObserver": 2,
+	"AddWitness":  3,
 }
 
 func (x ConfigChangeType) Enum() *ConfigChangeType {
@@ -729,6 +733,7 @@ type Membership struct {
 	Addresses      map[uint64]string `protobuf:"bytes,2,rep,name=addresses" json:"addresses,omitempty" protobuf_key:"varint,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Removed        map[uint64]bool   `protobuf:"bytes,3,rep,name=removed" json:"removed,omitempty" protobuf_key:"varint,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
 	Observers      map[uint64]string `protobuf:"bytes,4,rep,name=observers" json:"observers,omitempty" protobuf_key:"varint,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Witnesses      map[uint64]string `protobuf:"bytes,5,rep,name=witnesses" json:"witnesses,omitempty" protobuf_key:"varint,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 }
 
 func (m *Membership) Reset()         { *m = Membership{} }

--- a/raftpb/raft.proto
+++ b/raftpb/raft.proto
@@ -55,13 +55,15 @@ enum MessageType {
 enum EntryType {
 	ApplicationEntry  = 0;
 	ConfigChangeEntry = 1;
-  EncodedEntry = 2;
+    EncodedEntry      = 2;
+	MetadataEntry     = 3;
 }
 
 enum ConfigChangeType {
 	AddNode     = 0;
   RemoveNode  = 1;
   AddObserver = 2;
+  AddWitness = 3;
 }
 
 enum StateMachineType {

--- a/raftpb/raft.proto
+++ b/raftpb/raft.proto
@@ -123,6 +123,7 @@ message Membership {
   map<uint64, string> addresses   = 2;
   map<uint64, bool> removed       = 3;
   map<uint64, string> observers   = 4;
+  map<uint64, string> witnesses   = 5;
 }
 
 // field id 1 was used for optional string filename


### PR DESCRIPTION
Fundamental implementation to support witness role in the core raft library. Unit tests & integration tests are still in progress. The ideas are primarily from https://github.com/pingcap/raft-rs/issues/145

Specific changes made:

- Witness could be initialized
- Witness doesn't have a persistent log node
- Witness doesn't initiate election
- Replication request to witness doesn't contain real data, except config change request.

A thorough test should cover the following:

1. Witness could be initialized
2. Witness could be added
3. Witness could be removed
4. Witness could vote
5. Witness couldn’t start election
6. Witness will receive application entry as metadata entry
7. Witness will receive encoded entry as metadata entry
8. Witness will receive full config change entry
9. Witness couldn’t promote to any other role
10. Witness could be downgraded from any role
11. Witness would receive snapshot with dummy flag
12. Voting member should include witness

And will use code coverage tool to make sure all the newly added code paths are tested.

