### PR TITLE
Add Auto Promote Support for Observer

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -29,8 +29,8 @@ import (
 	"github.com/lni/dragonboat/v3/internal/vfs"
 	"github.com/lni/dragonboat/v3/logger"
 	"github.com/lni/dragonboat/v3/raftio"
-	"github.com/lni/dragonboat/v3/statemachine"
 	pb "github.com/lni/dragonboat/v3/raftpb"
+	"github.com/lni/dragonboat/v3/statemachine"
 	"github.com/lni/goutils/netutil"
 	"github.com/lni/goutils/stringutil"
 )

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"github.com/lni/dragonboat/v3/statemachine"
 	"testing"
 )
 
@@ -150,5 +151,12 @@ func TestLogDBConfigMemSize(t *testing.T) {
 	c4 := GetLargeMemLogDBConfig()
 	if c4.MemorySizeMB() != 8192 {
 		t.Errorf("size %d, want 8192", c4.MemorySizeMB())
+	}
+}
+
+func TestNonObserverCanNotSetAutoPromote(t *testing.T) {
+	cfg := Config{IsObserver: false, AutoPromoteCallback: func(result statemachine.Result) {}}
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("non-observer node can not use auto promote")
 	}
 }

--- a/internal/settings/soft.go
+++ b/internal/settings/soft.go
@@ -67,6 +67,18 @@ type soft struct {
 	// It is defined in terms of number of ticks.
 	InMemGCTimeout uint64
 
+	// PromotionReadTimeoutMs determines how long we will abort the read index operation
+	// for observer promotion.
+	PromotionReadIndexBackOff uint64
+
+	// PromotionConfigChangeTimeoutMs determines how long we will abort the config change
+	// for observer promotion.
+	PromotionConfigChangeTimeoutMs uint64
+
+	// MinInsyncIterations determines how many successful read index we perform before starting
+	// the observer promotion.
+	MinInsyncIterations uint64
+
 	//
 	// Multiraft
 	//
@@ -198,6 +210,8 @@ func getDefaultSoftSettings() soft {
 		MinEntrySliceFreeSize:          96,
 		IncomingReadIndexQueueLength:   4096,
 		IncomingProposalQueueLength:    2048,
+		PromotionReadIndexBackOff:               64,
+		PromotionConfigChangeTimeoutMs:          5000,
 		SnapshotStatusPushDelayMS:      1000,
 		PendingProposalShards:          16,
 		TaskQueueInitialCap:            64,

--- a/internal/vfs/vfs.go
+++ b/internal/vfs/vfs.go
@@ -21,7 +21,7 @@ import (
 
 	pvfs "github.com/cockroachdb/pebble/vfs"
 
-	gvfs "github.com/lni/goutils/vfs"
+	gvfs "github.com/cockroachdb/pebble/vfs"
 )
 
 // IFS is the vfs interface used by dragonboat.

--- a/promotion_manager.go
+++ b/promotion_manager.go
@@ -1,0 +1,199 @@
+// Copyright 2017-2019 Lei Ni (nilei81@gmail.com) and other Dragonboat authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dragonboat
+
+import (
+	"github.com/lni/dragonboat/v3/config"
+	"github.com/lni/dragonboat/v3/internal/settings"
+)
+
+type state string
+
+const (
+	Started          state = "Started"
+	PendingReadIndex state = "PendingReadIndex"
+	PendingPromotion state = "PendingPromotion"
+	BackOff          state = "BackOff"
+	Done             state = "Done"
+)
+
+var (
+	maxBackOff             = settings.Soft.PromotionReadIndexBackOff
+	pConfigChangeTimeoutMs = settings.Soft.PromotionConfigChangeTimeoutMs
+	minInsyncIterations    = settings.Soft.MinInsyncIterations
+	validTransitions       map[state][]state
+)
+
+// PromotionManager tracks and conducts auto promotion for observer nodes, so that user
+// no longer needs to do RPC call when the node is ready to be add into the quorum.
+// The workflow is as follow: Perform a couple rounds of readIndex and make sure they don't timeout
+// within election timeout. Then perform the config change from observer to require a promotion to follower.
+// Note that within the entire process if any of the steps fails, we will reset the counter, back-off a bit,
+// and do the whole thing again.
+type PromotionManager struct {
+	readIndexTimeoutMs     uint64
+	configChangeTimeoutMs  uint64
+	insyncIterationCounter uint64
+	minInsyncIterations    uint64
+	readIndex              func(readIndexTimeout uint64) (*RequestState, error)
+	promote                func(configChangeTimeout uint64) (*RequestState, error)
+	readIndexC             chan RequestResult
+	promoC                 chan RequestResult
+	pmState                state
+	backOffCounter         uint64
+	doneCb                 config.AutoPromoteCallbackFunc
+}
+
+func NewPromotionManager(readIndexTimeoutMs uint64,
+	readIndex func(readIndexTimeout uint64) (*RequestState, error),
+	promote func(configChangeTimeout uint64) (*RequestState, error),
+	doneCallback config.AutoPromoteCallbackFunc) *PromotionManager {
+	validTransitions = map[state][]state{
+		Started:          {PendingReadIndex},
+		BackOff:          {PendingReadIndex},
+		PendingReadIndex: {PendingPromotion, BackOff},
+		PendingPromotion: {Done, BackOff},
+	}
+	return &PromotionManager{
+		readIndexTimeoutMs:     readIndexTimeoutMs,
+		configChangeTimeoutMs:  pConfigChangeTimeoutMs,
+		insyncIterationCounter: 0,
+		minInsyncIterations:    minInsyncIterations,
+		readIndex:              readIndex,
+		promote:                promote,
+		promoC:                 nil,
+		pmState:                Started,
+		doneCb:                 doneCallback,
+	}
+}
+
+func (m *PromotionManager) transitTo(newState state) {
+	isValidTransition := false
+	for _, validState := range validTransitions[m.pmState] {
+		if validState == newState {
+			isValidTransition = true
+			break
+		}
+	}
+	if !isValidTransition {
+		plog.Panicf("Invalid transition from state %v to state %v", m.pmState, newState)
+	}
+	plog.Infof("Promotion manager is transiting from state %v to state %v", m.pmState, newState)
+	m.pmState = newState
+}
+
+// Process call triggers on every iteration when exec engine ticks, check
+// the promotion request result if there is an ongoing configuration
+// change and sends out readIndex request if needed.
+func (m *PromotionManager) Process() {
+	switch m.pmState {
+	case Started:
+		m.maybePerformReadIndex()
+	case BackOff:
+		m.maybePerformReadIndex()
+	case PendingReadIndex:
+		select {
+		case r := <-m.readIndexC:
+			m.processReadIndexResult(r)
+		default:
+		}
+	case PendingPromotion:
+		select {
+		case r := <-m.promoC:
+			m.processPromotionResult(r)
+			m.doneCb(r.result)
+		default:
+		}
+	case Done:
+	default:
+		plog.Panicf("Unknown state %v", m.pmState)
+	}
+
+	plog.Debugf("Current state: %v\n"+
+		"in sync iteration count: %v \n"+
+		"min in sync iteration: %v \n"+
+		"back off counter: %v",
+		m.pmState,
+		m.insyncIterationCounter,
+		m.minInsyncIterations,
+		m.backOffCounter)
+}
+
+func (m *PromotionManager) maybePerformReadIndex() {
+	if m.backOffCounter > 0 {
+		m.backOffCounter -= 1
+	} else {
+		r, err := m.readIndex(m.readIndexTimeoutMs)
+		if err != nil {
+			plog.Errorf("Promotion manager reads index failed: %v", err)
+			m.incrementBackOff()
+		} else {
+			m.readIndexC = r.CompletedC
+			m.transitTo(PendingReadIndex)
+		}
+	}
+}
+
+// A callback for the readIndex request Process. If consecutive successful readIndex requests are collected,
+// trigger the actual promotion. If any read index request times out or is too slow,
+// we will reset counter and do it again.
+func (m *PromotionManager) processReadIndexResult(result RequestResult) {
+	if result.Completed() {
+		m.insyncIterationCounter += 1
+		if m.insyncIterationCounter >= m.minInsyncIterations {
+			rs, err := m.promote(m.configChangeTimeoutMs)
+			if err != nil {
+				plog.Errorf("The config change request for observer promotion has failed: %v. Will reset", err)
+				m.reset()
+			} else {
+				m.promoC = rs.CompletedC
+				m.transitTo(PendingPromotion)
+			}
+		} else {
+			m.transitTo(BackOff)
+			m.maybePerformReadIndex()
+		}
+	} else {
+		plog.Infof("Promotion failed, will reset and retry.")
+		m.reset()
+	}
+}
+
+func (m *PromotionManager) processPromotionResult(r RequestResult) {
+	if r.Completed() {
+		m.transitTo(Done)
+		plog.Infof("The promotion is complete, deactivating the promotion tracker.")
+	} else {
+		m.insyncIterationCounter = 0
+		m.incrementBackOff()
+		m.transitTo(BackOff)
+		plog.Warningf("Last promotion was not successful as: %v, resetting the counter.", r)
+	}
+}
+
+func (m *PromotionManager) reset() {
+	m.insyncIterationCounter = 0
+	m.incrementBackOff()
+	m.transitTo(BackOff)
+}
+
+func (m *PromotionManager) incrementBackOff() {
+	m.backOffCounter *= 2
+	if m.backOffCounter > maxBackOff {
+		m.backOffCounter = maxBackOff
+	} else if m.backOffCounter == 0 {
+		m.backOffCounter = 1
+	}
+	return
+}

--- a/promotion_manager_test.go
+++ b/promotion_manager_test.go
@@ -1,0 +1,371 @@
+// Copyright 2017-2019 Lei Ni (nilei81@gmail.com) and other Dragonboat authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dragonboat
+
+import (
+	"github.com/lni/dragonboat/v3/statemachine"
+	"github.com/pkg/errors"
+	"testing"
+)
+
+func TestInitializePromotionManager(t *testing.T) {
+	m := NewPromotionManager(1000, nil, nil, nil)
+
+	if m.readIndexTimeoutMs != 1000 {
+		t.Errorf("read index timeout not 1000 milliseconds: %v", m.readIndexTimeoutMs)
+	}
+
+	if m.configChangeTimeoutMs != 5000 {
+		t.Errorf("config change timeout not 5000 milliseconds: %v", m.configChangeTimeoutMs)
+	}
+
+	if minInsyncIterations != 5 {
+		t.Errorf("minInsyncIterations not 5: %v", minInsyncIterations)
+	}
+
+	verifyIterationCounter(t, m, 0)
+
+	if m.promoC != nil {
+		t.Errorf("promoC not nil: %v", m)
+	}
+
+	if m.readIndexC != nil {
+		t.Errorf("readIndexC not nil: %v", m)
+	}
+
+	verifyBackOffCounter(t, m, 0)
+	verifyState(t, m, Started)
+}
+
+func verifyBackOffCounter(t *testing.T, m *PromotionManager, expected uint64) {
+	if m.backOffCounter != expected {
+		t.Errorf("backOffCounter not %v: actually get %v", expected, m.backOffCounter)
+	}
+}
+
+func TestStateTransition(t *testing.T) {
+	m := NewPromotionManager(10, nil, nil, nil)
+
+	tests := []struct {
+		from        state
+		to          state
+		shouldPanic bool
+	}{
+		// No state could be transit to Started
+		{BackOff, Started, true},
+		{PendingReadIndex, Started, true},
+		{PendingPromotion, Started, true},
+		// Done could not transit to any state
+		{Done, Started, true},
+		{Done, PendingReadIndex, true},
+		{Done, PendingPromotion, true},
+		{Done, BackOff, true},
+		// Pending states could go to BackOff
+		{PendingReadIndex, BackOff, false},
+		{PendingPromotion, BackOff, false},
+		// BackOff state could only go to PendingIndex
+		{BackOff, PendingReadIndex, false},
+		{BackOff, PendingPromotion, true},
+		// Started could only go to PendingReadIndex
+		{Started, PendingReadIndex, false},
+		{Started, PendingPromotion, true},
+		{Started, BackOff, true},
+	}
+	for idx, tt := range tests {
+		func() {
+			defer func() {
+				r := recover()
+				if r == nil {
+					if tt.shouldPanic {
+						t.Errorf("%d, failed to panic", idx)
+					}
+				}
+			}()
+			m.pmState = tt.from
+			m.transitTo(tt.to)
+		}()
+	}
+}
+
+func TestIncrementBackOff(t *testing.T) {
+	m := NewPromotionManager(10, nil, nil, nil)
+	tests := []struct {
+		initial  uint64
+		expected uint64
+	}{
+		{0, 1},
+		{4, 8},
+		{50, 64},
+		{128, 64},
+	}
+
+	for _, tt := range tests {
+		m.backOffCounter = tt.initial
+		m.incrementBackOff()
+		verifyBackOffCounter(t, m, tt.expected)
+	}
+}
+
+func TestReset(t *testing.T) {
+	m := NewPromotionManager(10, nil, nil, nil)
+	m.transitTo(PendingReadIndex)
+	m.backOffCounter = 4
+	m.reset()
+
+	verifyBackOffCounter(t, m, 8)
+	verifyIterationCounter(t, m, 0)
+	verifyState(t, m, BackOff)
+}
+
+func TestPerformReadIndex(t *testing.T) {
+	readIndexC := make(chan RequestResult)
+	m := NewPromotionManager(10, func(timeout uint64) (requestState *RequestState, e error) {
+		return &RequestState{
+			CompletedC: readIndexC,
+		}, nil
+	}, nil, nil)
+	m.maybePerformReadIndex()
+
+	verifyState(t, m, PendingReadIndex)
+
+	if m.readIndexC != readIndexC {
+		t.Errorf("ReadIndex channel not setup")
+	}
+
+	m.backOffCounter = 1
+	m.transitTo(BackOff)
+
+	m.maybePerformReadIndex()
+
+	verifyIterationCounter(t, m, 0)
+	verifyState(t, m, BackOff)
+}
+
+func TestReadIndexInnerFail(t *testing.T) {
+	m := NewPromotionManager(10, func(timeout uint64) (requestState *RequestState, e error) {
+		return &RequestState{}, errors.Errorf("Unknown error")
+	}, nil, nil)
+	m.maybePerformReadIndex()
+
+	if m.readIndexC != nil {
+		t.Errorf("readIndex channel should be nil")
+	}
+
+	verifyBackOffCounter(t, m, 1)
+	verifyIterationCounter(t, m, 0)
+	verifyState(t, m, Started)
+}
+
+func TestProcessReadIndexResultSuccess(t *testing.T) {
+	promoC := make(chan RequestResult)
+
+	m := NewPromotionManager(10, nil, func(configChangeTimeout uint64) (requestState *RequestState, e error) {
+		return &RequestState{
+			CompletedC: promoC,
+		}, nil
+	}, nil)
+	m.transitTo(PendingReadIndex)
+
+	m.insyncIterationCounter = 5
+	m.processReadIndexResult(RequestResult{
+		code: requestCompleted,
+	})
+
+	if m.promoC != promoC {
+		t.Errorf("Promotion not started")
+	}
+
+	verifyState(t, m, PendingPromotion)
+}
+
+func TestProcessReadIndexResultNotReady(t *testing.T) {
+	promoC := make(chan RequestResult)
+
+	m := NewPromotionManager(10, func(timeout uint64) (requestState *RequestState, e error) {
+		return &RequestState{}, nil
+	}, func(configChangeTimeout uint64) (requestState *RequestState, e error) {
+		return &RequestState{
+			CompletedC: promoC,
+		}, nil
+	}, nil)
+
+	m.insyncIterationCounter = 0
+	m.transitTo(PendingReadIndex)
+	m.processReadIndexResult(RequestResult{
+		code: requestCompleted,
+	})
+
+	if m.promoC != nil {
+		t.Errorf("PromoC not nil")
+	}
+
+	verifyIterationCounter(t, m, 1)
+
+	verifyState(t, m, PendingReadIndex)
+}
+
+func TestProcessReadIndexResultFail(t *testing.T) {
+	promoC := make(chan RequestResult)
+
+	m := NewPromotionManager(10, func(timeout uint64) (requestState *RequestState, e error) {
+		return &RequestState{}, nil
+	}, func(configChangeTimeout uint64) (requestState *RequestState, e error) {
+		return &RequestState{
+			CompletedC: promoC,
+		}, nil
+	}, nil)
+
+	m.insyncIterationCounter = 0
+	m.transitTo(PendingReadIndex)
+	m.processReadIndexResult(RequestResult{
+		code: requestTerminated,
+	})
+
+	verifyBackOffCounter(t, m, 1)
+	verifyIterationCounter(t, m, 0)
+	verifyState(t, m, BackOff)
+}
+
+func TestProcessReadIndexResultPromoFail(t *testing.T) {
+	promoC := make(chan RequestResult)
+
+	m := NewPromotionManager(10, func(timeout uint64) (requestState *RequestState, e error) {
+		return &RequestState{}, nil
+	}, func(configChangeTimeout uint64) (requestState *RequestState, e error) {
+		return &RequestState{
+			CompletedC: promoC,
+		}, errors.Errorf("expected error")
+	}, nil)
+
+	m.insyncIterationCounter = 5
+	m.transitTo(PendingReadIndex)
+	m.processReadIndexResult(RequestResult{
+		code: requestCompleted,
+	})
+
+	verifyBackOffCounter(t, m, 1)
+	verifyIterationCounter(t, m, 0)
+	verifyState(t, m, BackOff)
+}
+
+func verifyIterationCounter(t *testing.T, m *PromotionManager, expected uint64) {
+	if m.insyncIterationCounter != expected {
+		t.Errorf("insyncIterationCounter not %v: actually got %v", expected, m.insyncIterationCounter)
+	}
+}
+
+func verifyState(t *testing.T, m *PromotionManager, expectedState state) {
+	if m.pmState != expectedState {
+		t.Errorf("state not changing to %v, actually get %v", expectedState, m.pmState)
+	}
+}
+
+func TestProcessPromotionSuccess(t *testing.T) {
+	m := NewPromotionManager(10, nil, nil, nil)
+
+	m.transitTo(PendingReadIndex)
+	m.transitTo(PendingPromotion)
+	m.processPromotionResult(RequestResult{
+		code: requestCompleted,
+	})
+
+	verifyState(t, m, Done)
+}
+
+func TestProcessPromotionFail(t *testing.T) {
+	m := NewPromotionManager(10, nil, nil, nil)
+	m.insyncIterationCounter = 3
+
+	m.transitTo(PendingReadIndex)
+	m.transitTo(PendingPromotion)
+	m.processPromotionResult(RequestResult{
+		code: requestTimeout,
+	})
+
+	verifyIterationCounter(t, m, 0)
+
+	verifyState(t, m, BackOff)
+}
+
+func TestFullProcess(t *testing.T) {
+	readIndexCounter := uint64(0)
+	readIndexC := make(chan RequestResult, 1)
+	promoC := make(chan RequestResult, 1)
+	promoC <- RequestResult{
+		code: requestCompleted,
+	}
+
+	promoCt := uint64(0)
+	m := NewPromotionManager(10, func(timeout uint64) (requestState *RequestState, e error) {
+		readIndexCounter += 1
+		return &RequestState{
+			CompletedC: readIndexC,
+		}, nil
+	}, func(configChangeTimeout uint64) (requestState *RequestState, e error) {
+		promoCt += 1
+		return &RequestState{
+			CompletedC: promoC,
+		}, nil
+	}, func(result statemachine.Result) {})
+
+	tests := []struct {
+		expectedState       state
+		expectedReadIndexCt uint64
+		expectedPromoCt     uint64
+		shouldPushReadIndex bool
+	}{
+		{PendingReadIndex, 1, 0, true},
+		{PendingReadIndex, 2, 0, true},
+		{PendingReadIndex, 3, 0, true},
+		{BackOff, 3, 0, false},
+		{BackOff, 3, 0, false},
+		{PendingReadIndex, 4, 0, true},
+		{PendingReadIndex, 5, 0, true},
+		{PendingReadIndex, 6, 0, true},
+		{PendingReadIndex, 7, 0, true},
+		{PendingReadIndex, 8, 0, true},
+		{PendingPromotion, 8, 1, false},
+		{Done, 8, 1, false},
+		{Done, 8, 1, false},
+		{Done, 8, 1, false},
+	}
+
+	injectFailureIdx := 2
+
+	for idx, tt := range tests {
+		m.Process()
+		verifyState(t, m, tt.expectedState)
+		if readIndexCounter != tt.expectedReadIndexCt {
+			t.Errorf("test failed at step %v for mismatching read index ct: expected %v, actual %v",
+				idx, tt.expectedReadIndexCt, readIndexCounter)
+		}
+
+		if promoCt != tt.expectedPromoCt {
+			t.Errorf("test failed at step %v for mismatching promo ct: expected %v, actual %v",
+				idx, tt.expectedPromoCt, promoCt)
+		}
+
+		if tt.shouldPushReadIndex {
+			if idx == injectFailureIdx {
+				readIndexC <- RequestResult{
+					code: requestTimeout,
+				}
+			} else {
+				readIndexC <- RequestResult{
+					code: requestCompleted,
+				}
+			}
+		}
+	}
+}

--- a/requests.go
+++ b/requests.go
@@ -96,17 +96,6 @@ var (
 	ErrPendingLeaderTransferExist = errors.New("pending leader transfer exist")
 )
 
-// IsTempError returns a boolean value indicating whether the specified error
-// is a temporary error that worth to be retried later with the exact same
-// input, potentially on a more suitable NodeHost instance.
-func IsTempError(err error) bool {
-	return err == ErrSystemBusy ||
-		err == ErrBadKey ||
-		err == ErrPendingConfigChangeExist ||
-		err == ErrClusterClosed ||
-		err == ErrSystemStopped
-}
-
 // RequestResultCode is the result code returned to the client to indicate the
 // outcome of the request.
 type RequestResultCode int


### PR DESCRIPTION
These days when user tries to add a new raft node and avoid unnecessary downtime, the first step is to add the new node as observer, wait it to catch up and then promote it as a follower manually. This whole process could be automated in Dragonboat.

The detailed motivation is described in Raft paper 4.2.1, but the implementation takes a different approach. In the paper, leader is responsible for tracking the observer progress by monitoring the new entry replication speed, and promote the observer when one replication round is less than election timeout, which suggests the gap is sufficiently small. This idea adds burden to leader logic complexity and overhead for leadership transfer.

Instead, Dragonboat chooses a self-nomination approach through observer initiates readIndex call to make sure it is sufficiently catching up with the leader. If we see consecutive rounds of readIndex success within election timeout, the observer will trigger a config change to add itself as a follower on next round. This is a de-centralized design which saves the dependency on elected leader to decide the role, thus easier to reason about.