### PR TITLE
Disable witness readIndex

### DIFF
--- a/internal/raft/raft_etcd_test.go
+++ b/internal/raft/raft_etcd_test.go
@@ -2984,9 +2984,9 @@ func newTestConfig(id uint64, election, heartbeat int) *config.Config {
 
 func newRateLimitedTestConfig(id uint64, election, heartbeat int, maxLogSize int) *config.Config {
 	return &config.Config{
-		NodeID:       id,
-		ElectionRTT:  uint64(election),
-		HeartbeatRTT: uint64(heartbeat),
+		NodeID:          id,
+		ElectionRTT:     uint64(election),
+		HeartbeatRTT:    uint64(heartbeat),
 		MaxInMemLogSize: uint64(maxLogSize),
 	}
 }

--- a/internal/raft/raft_test.go
+++ b/internal/raft/raft_test.go
@@ -2760,6 +2760,32 @@ func TestHandleLeaderReadIndex(t *testing.T) {
 	}
 }
 
+func TestWitnessReadIndex(t *testing.T) {
+	r := newTestRaft(1, []uint64{1}, 5, 1, NewTestLogDB())
+
+	r.becomeFollower(1, NoLeader)
+	if r.hasCommittedEntryAtCurrentTerm() {
+		t.Errorf("unexpectedly set hasCommittedEntryAtCurrentTerm")
+	}
+	r.becomeCandidate()
+	r.becomeLeader()
+
+	r.addWitness(2)
+
+	msg := pb.Message{
+		Type:     pb.ReadIndex,
+		Hint:     101,
+		HintHigh: 1002,
+		From:     2,
+	}
+
+	r.handleLeaderReadIndex(msg)
+
+	if len(r.readIndex.pending) != 0 || len(r.readIndex.queue) != 0 {
+		t.Errorf("readIndex updated unexpectedly")
+	}
+}
+
 func TestVotingMemberLengthMismatchWillResetMatchArray(t *testing.T) {
 	r := newTestRaft(1, []uint64{1, 2, 3}, 5, 1, NewTestLogDB())
 	r.becomeFollower(1, NoLeader)


### PR DESCRIPTION
A minor fix for witness logic as it should be prohibited to perform readIndex