### PR TITLE
raft: introduce DisableProposalForwarding option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -179,6 +179,10 @@ type Config struct {
 	//
 	// Quiesce support is currently experimental.
 	Quiesce bool
+	// DisableProposalForwarding set to true means that followers will drop
+	// proposals, rather than forwarding them to the leader. Proposal from
+	// follower or observer will be dropped.
+	DisableProposalForwarding bool
 }
 
 // Validate validates the Config instance and return an error when any member

--- a/internal/raft/raft_test.go
+++ b/internal/raft/raft_test.go
@@ -2397,6 +2397,23 @@ func TestFollowerRedirectProposeMessageToLeader(t *testing.T) {
 	}
 }
 
+func TestFollowerNotRedirectProposeMessageToLeader(t *testing.T) {
+	r := newTestRaft(1, []uint64{1, 2}, 5, 1, NewTestLogDB())
+	r.disableProposalForwarding = true
+	r.becomeFollower(10, 2)
+	m := pb.Message{
+		Type:    pb.Propose,
+		Entries: []pb.Entry{{Cmd: []byte("test-data")}},
+	}
+	ne(r.handleFollowerPropose(m), t)
+	if len(r.msgs) > 0 {
+		t.Fatalf("unexpected proposal forwarding")
+	}
+	if len(r.droppedEntries) != 1 {
+		t.Fatalf("propose wasn't dropped %d", len(r.droppedEntries))
+	}
+}
+
 func TestFollowerRedirectLeaderTransferMessageToLeader(t *testing.T) {
 	r := newTestRaft(1, []uint64{1, 2}, 5, 1, NewTestLogDB())
 	r.becomeFollower(10, 2)


### PR DESCRIPTION
DisableProposalForwarding set to true means that followers will drop
proposals, rather than forwarding them to the leader. Proposal from
follower or observer will be dropped.

One use case for this feature would be in a situation where the Raft leader
is used to compute the data of a proposal, for example, adding a timestamp
from a hybrid logical clock to data in a monotonically increasing way.
Forwarding should be disabled to prevent a follower with an inaccurate hybrid
logical clock from assigning the timestamp and then forwarding the data
to the leader.