### PR TITLE
Remove reallocation of batch+entries preventing huge memory churn

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -1144,8 +1144,6 @@ func (e *engine) applyWorkerMain(workerID uint64) {
 			if err := e.processApplies(a, nodes, batch, entries); err != nil {
 				panicNow(err)
 			}
-			batch = make([]rsm.Task, 0, taskBatchSize)
-			entries = make([]sm.Entry, 0, taskBatchSize)
 		case <-e.applyCCIReady.waitCh(workerID):
 			nodes, cci = e.loadApplyNodes(workerID, cci, nodes)
 		case <-e.applyWorkReady.waitCh(workerID):

--- a/engine.go
+++ b/engine.go
@@ -1133,6 +1133,7 @@ func (e *engine) applyWorkerMain(workerID uint64) {
 	batch := make([]rsm.Task, 0, taskBatchSize)
 	entries := make([]sm.Entry, 0, taskBatchSize)
 	cci := uint64(0)
+	count := uint64(0)
 	for {
 		select {
 		case <-e.taskStopper.ShouldStop():
@@ -1143,6 +1144,11 @@ func (e *engine) applyWorkerMain(workerID uint64) {
 			a := make(map[uint64]struct{})
 			if err := e.processApplies(a, nodes, batch, entries); err != nil {
 				panicNow(err)
+			}
+			count++
+			if count%200 == 0 {
+				batch = make([]rsm.Task, 0, taskBatchSize)
+				entries = make([]sm.Entry, 0, taskBatchSize)
 			}
 		case <-e.applyCCIReady.waitCh(workerID):
 			nodes, cci = e.loadApplyNodes(workerID, cci, nodes)


### PR DESCRIPTION
In our environment we have detected that `applyWorkerMain` causes quite a lot (60-70% in our case) of allocations in our system. I have tracked down the issue to the reallocation of those slices, the reallocation makes a little sense to me as `processApplies` always trims the slices to 0 len `[:0]` at the beginning of its run.