### PR TITLE
get leader vote only after leader persisted

### DIFF
--- a/internal/raft/peer.go
+++ b/internal/raft/peer.go
@@ -354,6 +354,10 @@ func (p *Peer) getUpdate(moreToApply bool,
 	return ud, nil
 }
 
+func (p *Peer) CheckVolatile() {
+	p.raft.checkVolatile()
+}
+
 func checkLaunchRequest(config config.Config,
 	addresses []PeerAddress, initial bool, newNode bool) {
 	if config.NodeID == 0 {

--- a/node.go
+++ b/node.go
@@ -1028,6 +1028,7 @@ func (n *node) applyRaftUpdates(ud pb.Update) {
 }
 
 func (n *node) processRaftUpdate(ud pb.Update) error {
+	n.p.CheckVolatile()
 	if err := n.logReader.Append(ud.EntriesToSave); err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently get leader vote before persisted, which may result in data inconsistent if leader crashes.

E.g., 3 nodes: 1,2,3, leader is 1.

Get vote of 2, and 1 not persisted
leader crash-> 2 get voted -> 1 up -> 2 crash -> 1 voted again
The system has two live nodes (1, 3), but the committed log is lost.

Or consider the single quorum scenario.
In current implementation, it will commit even before log persisted, which is against the WAL semantic.