### PR TITLE
add wait ready option for start replica

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -193,6 +193,9 @@ type Config struct {
 	//
 	// Quiesce support is currently experimental.
 	Quiesce bool
+	// WaitReady specifies whether to wait for the node to transition
+	// from recovering to ready state before returning from StartReplica.
+	WaitReady bool
 }
 
 // Validate validates the Config instance and return an error when any member

--- a/node.go
+++ b/node.go
@@ -1500,7 +1500,6 @@ func (n *node) processStatusTransition() bool {
 func (n *node) processUninitializedNodeStatus() bool {
 	if !n.initialized() {
 		plog.Debugf("%s checking initial snapshot", n.id())
-		n.ss.setRecovering()
 		n.reportRecoverSnapshot(rsm.Task{
 			Recover: true,
 			Initial: true,


### PR DESCRIPTION
Hi @lni,

this is the pull request for the bespoken feature in #268. Unfortunately, that one was accidentally closed, so I had to create a new one.

I've moved the option ``WaitReady`` into the node ``Config``. I'm very undecided there.. I see this option more related to the start call as to the node ``Config``, but with this we have the smallest API change and no upgrade problems.