### PR TITLE
[BUG FIX] fixes panic recovery in nodehost.NewNodeHost

### DIFF
--- a/nodehost.go
+++ b/nodehost.go
@@ -338,8 +338,11 @@ func NewNodeHost(nhConfig config.NodeHostConfig) (*NodeHost, error) {
 	defer func() {
 		if r := recover(); r != nil {
 			nh.Close()
-			if r, ok := r.(error); ok {
-				panicNow(r)
+			switch err := r.(type) {
+			case error:
+				panicNow(err)
+			case string:
+				panicNow(errors.New(err))
 			}
 		}
 	}()


### PR DESCRIPTION
Function NewNodeHost (nodehost:339)

When panic happens it's message is type-asserted as error, but often panic() is called with just a string. As a result panic is silently recovered without calling panicNow() and nil NodeHost instance is returned without any error. It is now fixed.