### PR TITLE
dragonboat: replace atomic operations with atomic.Bool

### DIFF
--- a/internal/tests/concurrentkv.go
+++ b/internal/tests/concurrentkv.go
@@ -51,7 +51,7 @@ type ConcurrentKVTest struct {
 	ReplicaID        uint64
 	kvdata           unsafe.Pointer
 	externalFileTest bool
-	closed           uint32
+	closed           atomic.Bool
 }
 
 // NewConcurrentKVTest creates and return a new KVTest object.
@@ -201,7 +201,7 @@ func (s *ConcurrentKVTest) RecoverFromSnapshot(r io.Reader,
 
 // Close closes the IStateMachine instance
 func (s *ConcurrentKVTest) Close() error {
-	atomic.StoreUint32(&s.closed, 1)
+	s.closed.Store(true)
 	return nil
 }
 
@@ -231,5 +231,5 @@ func (s *ConcurrentKVTest) GetHash() (uint64, error) {
 }
 
 func (s *ConcurrentKVTest) isClosed() bool {
-	return atomic.LoadUint32(&s.closed) == 1
+	return s.closed.Load()
 }

--- a/internal/tests/fakedisk.go
+++ b/internal/tests/fakedisk.go
@@ -26,7 +26,7 @@ import (
 
 // FakeDiskSM is a test state machine.
 type FakeDiskSM struct {
-	SlowOpen       uint32
+	SlowOpen       atomic.Bool
 	initialApplied uint64
 	count          uint64
 	aborted        bool
@@ -40,7 +40,7 @@ func NewFakeDiskSM(initialApplied uint64) *FakeDiskSM {
 
 // Open opens the state machine.
 func (f *FakeDiskSM) Open(stopc <-chan struct{}) (uint64, error) {
-	for atomic.LoadUint32(&f.SlowOpen) > 0 {
+	for f.SlowOpen.Load() {
 		time.Sleep(10 * time.Millisecond)
 	}
 	return f.initialApplied, nil

--- a/nodehost_test.go
+++ b/nodehost_test.go
@@ -2439,7 +2439,7 @@ func TestOnDiskStateMachineDoesNotSupportClientSession(t *testing.T) {
 func TestStaleReadOnUninitializedNodeReturnError(t *testing.T) {
 	fs := vfs.GetTestFS()
 	fakeDiskSM := tests.NewFakeDiskSM(0)
-	atomic.StoreUint32(&fakeDiskSM.SlowOpen, 1)
+	fakeDiskSM.SlowOpen.Store(true)
 	to := &testOption{
 		createOnDiskSM: func(uint64, uint64) sm.IOnDiskStateMachine {
 			return fakeDiskSM
@@ -2451,7 +2451,7 @@ func TestStaleReadOnUninitializedNodeReturnError(t *testing.T) {
 			_, err := nh.StaleRead(1, nil)
 			require.ErrorIs(t, err, ErrShardNotInitialized,
 				"expected to return ErrShardNotInitialized")
-			atomic.StoreUint32(&fakeDiskSM.SlowOpen, 0)
+			fakeDiskSM.SlowOpen.Store(false)
 			for !n.initialized() {
 				runtime.Gosched()
 			}
@@ -2467,7 +2467,7 @@ func TestStaleReadOnUninitializedNodeReturnError(t *testing.T) {
 func TestStartReplicaWaitForReadiness(t *testing.T) {
 	fs := vfs.GetTestFS()
 	fakeDiskSM := tests.NewFakeDiskSM(0)
-	atomic.StoreUint32(&fakeDiskSM.SlowOpen, 1)
+	fakeDiskSM.SlowOpen.Store(true)
 	to := &testOption{
 		defaultTestNode: false,
 		noElection:      true,
@@ -2476,7 +2476,7 @@ func TestStartReplicaWaitForReadiness(t *testing.T) {
 			cfg.WaitReady = true
 
 			go func() {
-				defer atomic.StoreUint32(&fakeDiskSM.SlowOpen, 0)
+				defer fakeDiskSM.SlowOpen.Store(false)
 				var n *node
 				var ok bool
 

--- a/quiesce.go
+++ b/quiesce.go
@@ -29,15 +29,15 @@ type quiesceState struct {
 	idleSince           uint64
 	exitQuiesceTick     uint64
 	enabled             bool
-	newQuiesceStateFlag uint32
+	newQuiesceStateFlag atomic.Bool
 }
 
 func (q *quiesceState) setNewQuiesceStateFlag() {
-	atomic.StoreUint32(&q.newQuiesceStateFlag, 1)
+	q.newQuiesceStateFlag.Store(true)
 }
 
 func (q *quiesceState) newQuiesceState() bool {
-	return atomic.SwapUint32(&q.newQuiesceStateFlag, 0) == 1
+	return q.newQuiesceStateFlag.Swap(false)
 }
 
 func (q *quiesceState) tick() uint64 {

--- a/request.go
+++ b/request.go
@@ -255,19 +255,19 @@ func (p *logicalClock) getTick() uint64 {
 }
 
 type ready struct {
-	val uint32
+	val atomic.Bool
 }
 
 func (r *ready) ready() bool {
-	return atomic.LoadUint32(&r.val) == 1
+	return r.val.Load()
 }
 
 func (r *ready) clear() {
-	atomic.StoreUint32(&r.val, 0)
+	r.val.Store(false)
 }
 
 func (r *ready) set() {
-	atomic.StoreUint32(&r.val, 1)
+	r.val.Store(true)
 }
 
 // SysOpState is the object used to provide system maintenance operation result

--- a/snapshotstate.go
+++ b/snapshotstate.go
@@ -67,9 +67,9 @@ type snapshotState struct {
 	reqSnapshotIndex uint64
 	compactLogTo     uint64
 	compactedTo      uint64
-	savingFlag       uint32
-	recoveringFlag   uint32
-	streamingFlag    uint32
+	savingFlag       atomic.Bool
+	recoveringFlag   atomic.Bool
+	streamingFlag    atomic.Bool
 	recoverReady     snapshotTask
 	saveReady        snapshotTask
 	streamReady      snapshotTask
@@ -79,39 +79,39 @@ type snapshotState struct {
 }
 
 func (rs *snapshotState) recovering() bool {
-	return atomic.LoadUint32(&rs.recoveringFlag) == 1
+	return rs.recoveringFlag.Load()
 }
 
 func (rs *snapshotState) setRecovering() {
-	atomic.StoreUint32(&rs.recoveringFlag, 1)
+	rs.recoveringFlag.Store(true)
 }
 
 func (rs *snapshotState) clearRecovering() {
-	atomic.StoreUint32(&rs.recoveringFlag, 0)
+	rs.recoveringFlag.Store(false)
 }
 
 func (rs *snapshotState) streaming() bool {
-	return atomic.LoadUint32(&rs.streamingFlag) == 1
+	return rs.streamingFlag.Load()
 }
 
 func (rs *snapshotState) setStreaming() {
-	atomic.StoreUint32(&rs.streamingFlag, 1)
+	rs.streamingFlag.Store(true)
 }
 
 func (rs *snapshotState) clearStreaming() {
-	atomic.StoreUint32(&rs.streamingFlag, 0)
+	rs.streamingFlag.Store(false)
 }
 
 func (rs *snapshotState) saving() bool {
-	return atomic.LoadUint32(&rs.savingFlag) == 1
+	return rs.savingFlag.Load()
 }
 
 func (rs *snapshotState) setSaving() {
-	atomic.StoreUint32(&rs.savingFlag, 1)
+	rs.savingFlag.Store(true)
 }
 
 func (rs *snapshotState) clearSaving() {
-	atomic.StoreUint32(&rs.savingFlag, 0)
+	rs.savingFlag.Store(false)
 }
 
 func (rs *snapshotState) setIndex(index uint64) {


### PR DESCRIPTION
This PR replaces atomic operations with atomic types for improved clarity and safety. Only `atomic.Bool` fields are changed.

See https://cuonglm.xyz/post/go119_atomic_types/