### PR TITLE
Add FailHandler to node

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -196,6 +196,13 @@ type Config struct {
 	// WaitReady specifies whether to wait for the node to transition
 	// from recovering to ready state before returning from StartReplica.
 	WaitReady bool
+	// FailHandler is an optional function that will be called to handle an
+	// IOnDiskStateMachine failure. If set, the replica will be stopped when the
+	// state machine returns an error (from all methods except Lookup), and then
+	// the FailHandler will be invoked. This is intended for cases where the state
+	// machine cannot continue (e.g., disk failure) but you don't want Dragonboat
+	// to panic.
+	FailHandler func(err error)
 }
 
 // Validate validates the Config instance and return an error when any member

--- a/config/config.go
+++ b/config/config.go
@@ -196,13 +196,13 @@ type Config struct {
 	// WaitReady specifies whether to wait for the node to transition
 	// from recovering to ready state before returning from StartReplica.
 	WaitReady bool
-	// FailHandler is an optional function that will be called to handle an
+	// FaultHandler is an optional function that will be called to handle an
 	// IOnDiskStateMachine failure. If set, the replica will be stopped when the
 	// state machine returns an error (from all methods except Lookup), and then
-	// the FailHandler will be invoked. This is intended for cases where the state
+	// the FaultHandler will be invoked. This is intended for cases where the state
 	// machine cannot continue (e.g., disk failure) but you don't want Dragonboat
 	// to panic.
-	FailHandler func(err error)
+	FaultHandler func(err error)
 }
 
 // Validate validates the Config instance and return an error when any member

--- a/internal/rsm/adapter.go
+++ b/internal/rsm/adapter.go
@@ -254,6 +254,26 @@ type ITestFS interface {
 	SetTestFS(fs config.IFS)
 }
 
+type UserSmError struct {
+	wrapped error
+}
+
+func (e UserSmError) Error() string {
+	return e.wrapped.Error()
+}
+
+func (e UserSmError) Unwrap() error {
+	return e.wrapped
+}
+
+func UnwrapUserSmError(err error) error {
+	smErr := UserSmError{}
+	if errors.As(err, &smErr) {
+		return smErr.Unwrap()
+	}
+	return nil
+}
+
 // OnDiskStateMachine is the type to represent an on disk state machine.
 type OnDiskStateMachine struct {
 	sm     sm.IOnDiskStateMachine
@@ -289,6 +309,7 @@ func (s *OnDiskStateMachine) Open(stopc <-chan struct{}) (uint64, error) {
 	}
 	s.opened = true
 	applied, err := s.sm.Open(stopc)
+	err = s.wrapUserError(err)
 	return applied, errors.WithStack(err)
 }
 
@@ -296,6 +317,7 @@ func (s *OnDiskStateMachine) Open(stopc <-chan struct{}) (uint64, error) {
 func (s *OnDiskStateMachine) Update(entries []sm.Entry) ([]sm.Entry, error) {
 	s.ensureOpened()
 	results, err := s.sm.Update(entries)
+	err = s.wrapUserError(err)
 	return results, errors.WithStack(err)
 }
 
@@ -314,33 +336,42 @@ func (s *OnDiskStateMachine) NALookup(query []byte) ([]byte, error) {
 // Sync synchronizes all in-core state with that on disk.
 func (s *OnDiskStateMachine) Sync() error {
 	s.ensureOpened()
-	return errors.WithStack(s.sm.Sync())
+	err := s.sm.Sync()
+	err = s.wrapUserError(err)
+	return errors.WithStack(err)
 }
 
 // Prepare makes preparations for taking concurrent snapshot.
 func (s *OnDiskStateMachine) Prepare() (interface{}, error) {
 	s.ensureOpened()
 	results, err := s.sm.PrepareSnapshot()
+	err = s.wrapUserError(err)
 	return results, errors.WithStack(err)
 }
 
 // Save saves the snapshot.
 func (s *OnDiskStateMachine) Save(ctx interface{},
-	w io.Writer, fc sm.ISnapshotFileCollection, stopc <-chan struct{}) error {
+	w io.Writer, fc sm.ISnapshotFileCollection, stopc <-chan struct{}) (err error) {
 	s.ensureOpened()
-	return errors.WithStack(s.sm.SaveSnapshot(ctx, w, stopc))
+	err = s.sm.SaveSnapshot(ctx, w, stopc)
+	err = s.wrapUserError(err)
+	return errors.WithStack(err)
 }
 
 // Recover recovers the state machine from a snapshot.
 func (s *OnDiskStateMachine) Recover(r io.Reader,
 	fs []sm.SnapshotFile, stopc <-chan struct{}) error {
 	s.ensureOpened()
-	return errors.WithStack(s.sm.RecoverFromSnapshot(r, stopc))
+	err := s.sm.RecoverFromSnapshot(r, stopc)
+	err = s.wrapUserError(err)
+	return errors.WithStack(err)
 }
 
 // Close closes the state machine.
 func (s *OnDiskStateMachine) Close() error {
-	return errors.WithStack(s.sm.Close())
+	err := s.sm.Close()
+	err = s.wrapUserError(err)
+	return errors.WithStack(err)
 }
 
 // GetHash returns the uint64 hash value representing the state of a state
@@ -351,6 +382,7 @@ func (s *OnDiskStateMachine) GetHash() (uint64, error) {
 		return 0, sm.ErrNotImplemented
 	}
 	h, err := s.h.GetHash()
+	err = s.wrapUserError(err)
 	return h, errors.WithStack(err)
 }
 
@@ -375,4 +407,15 @@ func (s *OnDiskStateMachine) ensureOpened() {
 	if !s.opened {
 		panic("not opened")
 	}
+}
+
+func (s *OnDiskStateMachine) wrapUserError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, sm.ErrSnapshotAborted) {
+		return err
+	}
+
+	return UserSmError{wrapped: err}
 }

--- a/internal/tests/fakedisk.go
+++ b/internal/tests/fakedisk.go
@@ -31,6 +31,14 @@ type FakeDiskSM struct {
 	count          uint64
 	aborted        bool
 	recovered      bool
+
+	OpenErr            atomic.Pointer[error]
+	CloseErr           atomic.Pointer[error]
+	UpdateErr          atomic.Pointer[error]
+	SyncErr            atomic.Pointer[error]
+	PrepareSnapshotErr atomic.Pointer[error]
+	SaveSnapshotErr    atomic.Pointer[error]
+	RecoverErr         atomic.Pointer[error]
 }
 
 // NewFakeDiskSM creates a new fake disk sm for testing purpose.
@@ -42,6 +50,10 @@ func NewFakeDiskSM(initialApplied uint64) *FakeDiskSM {
 func (f *FakeDiskSM) Open(stopc <-chan struct{}) (uint64, error) {
 	for atomic.LoadUint32(&f.SlowOpen) > 0 {
 		time.Sleep(10 * time.Millisecond)
+	}
+	err := f.OpenErr.Load()
+	if err != nil {
+		return 0, *err
 	}
 	return f.initialApplied, nil
 }
@@ -68,6 +80,11 @@ func (f *FakeDiskSM) Recovered() bool {
 
 // Update updates the state machine.
 func (f *FakeDiskSM) Update(ents []sm.Entry) ([]sm.Entry, error) {
+	err := f.UpdateErr.Load()
+	if err != nil {
+		return nil, *err
+	}
+
 	for _, e := range ents {
 		if e.Index <= f.initialApplied {
 			panic("already applied index received again")
@@ -88,18 +105,30 @@ func (f *FakeDiskSM) Lookup(query interface{}) (interface{}, error) {
 
 // PrepareSnapshot prepares snapshotting.
 func (f *FakeDiskSM) PrepareSnapshot() (interface{}, error) {
+	err := f.PrepareSnapshotErr.Load()
+	if err != nil {
+		return nil, *err
+	}
 	pit := &FakeDiskSM{initialApplied: f.initialApplied, count: f.count}
 	return pit, nil
 }
 
 // Sync synchronize all in-core state.
 func (f *FakeDiskSM) Sync() error {
+	err := f.SyncErr.Load()
+	if err != nil {
+		return *err
+	}
 	return nil
 }
 
 // SaveSnapshot saves the state to a snapshot.
 func (f *FakeDiskSM) SaveSnapshot(ctx interface{},
 	w io.Writer, stopc <-chan struct{}) error {
+	err := f.SaveSnapshotErr.Load()
+	if err != nil {
+		return *err
+	}
 	if !f.aborted {
 		f.aborted = true
 		return sm.ErrSnapshotAborted
@@ -121,6 +150,10 @@ func (f *FakeDiskSM) SaveSnapshot(ctx interface{},
 // RecoverFromSnapshot recovers the state of the state machine from a snapshot.
 func (f *FakeDiskSM) RecoverFromSnapshot(r io.Reader,
 	stopc <-chan struct{}) error {
+	err := f.RecoverErr.Load()
+	if err != nil {
+		return *err
+	}
 	f.recovered = true
 	v := make([]byte, 8)
 	if _, err := io.ReadFull(r, v); err != nil {
@@ -137,6 +170,10 @@ func (f *FakeDiskSM) RecoverFromSnapshot(r io.Reader,
 
 // Close closes the state machine.
 func (f *FakeDiskSM) Close() error {
+	err := f.CloseErr.Load()
+	if err != nil {
+		return *err
+	}
 	return nil
 }
 

--- a/node.go
+++ b/node.go
@@ -127,7 +127,7 @@ type node struct {
 	logDBLimited          bool
 	rateLimited           bool
 	notifyCommit          bool
-	userStateMachineErr   error
+	userStateMachineErr   atomic.Pointer[error]
 }
 
 var _ rsm.INode = (*node)(nil)
@@ -592,7 +592,7 @@ func (n *node) smClose() error {
 	userErr := rsm.UnwrapUserSmError(err)
 	if userErr != nil && n.config.FaultHandler != nil {
 		plog.Errorf("%s SM close failed", n.id())
-		n.userStateMachineErr = userErr
+		n.userStateMachineErr.CompareAndSwap(nil, &userErr)
 		return nil
 	}
 
@@ -600,9 +600,10 @@ func (n *node) smClose() error {
 }
 
 func (n *node) callFailHandler() {
-	if n.userStateMachineErr != nil && n.config.FaultHandler != nil {
+	err := n.userStateMachineErr.Load()
+	if err != nil && n.config.FaultHandler != nil {
 		go func() {
-			n.config.FaultHandler(n.userStateMachineErr)
+			n.config.FaultHandler(*err)
 		}()
 	}
 }
@@ -1768,7 +1769,7 @@ func (n *node) handleUserStateMachineError(err error) bool {
 		return false
 	}
 
-	n.userStateMachineErr = err
+	n.userStateMachineErr.CompareAndSwap(nil, &err)
 	n.requestRemoval()
 	return true
 }

--- a/node.go
+++ b/node.go
@@ -590,7 +590,7 @@ func (n *node) smClose() error {
 	err := n.sm.Close()
 
 	userErr := rsm.UnwrapUserSmError(err)
-	if userErr != nil && n.config.FailHandler != nil {
+	if userErr != nil && n.config.FaultHandler != nil {
 		plog.Errorf("%s SM close failed", n.id())
 		n.userStateMachineErr = userErr
 		return nil
@@ -600,9 +600,9 @@ func (n *node) smClose() error {
 }
 
 func (n *node) callFailHandler() {
-	if n.userStateMachineErr != nil && n.config.FailHandler != nil {
+	if n.userStateMachineErr != nil && n.config.FaultHandler != nil {
 		go func() {
-			n.config.FailHandler(n.userStateMachineErr)
+			n.config.FaultHandler(n.userStateMachineErr)
 		}()
 	}
 }

--- a/node.go
+++ b/node.go
@@ -127,6 +127,7 @@ type node struct {
 	logDBLimited          bool
 	rateLimited           bool
 	notifyCommit          bool
+	userStateMachineErr   error
 }
 
 var _ rsm.INode = (*node)(nil)
@@ -580,7 +581,30 @@ func (n *node) getLeaderID() (uint64, uint64, bool) {
 }
 
 func (n *node) destroy() error {
-	return n.sm.Close()
+	err := n.smClose()
+	n.callFailHandler()
+	return err
+}
+
+func (n *node) smClose() error {
+	err := n.sm.Close()
+
+	userErr := rsm.UnwrapUserSmError(err)
+	if userErr != nil && n.config.FailHandler != nil {
+		plog.Errorf("%s SM close failed", n.id())
+		n.userStateMachineErr = userErr
+		return nil
+	}
+
+	return err
+}
+
+func (n *node) callFailHandler() {
+	if n.userStateMachineErr != nil && n.config.FailHandler != nil {
+		go func() {
+			n.config.FailHandler(n.userStateMachineErr)
+		}()
+	}
 }
 
 func (n *node) destroyed() bool {
@@ -760,6 +784,14 @@ func (n *node) doSave(req rsm.SSRequest) (uint64, error) {
 	}
 	ss, ssenv, err := n.sm.Save(req)
 	if err != nil {
+		if n.handleUserStateMachineError(err) {
+			plog.Errorf("%s SM failed snapshot save: %v", n.id(), err)
+			if ssenv != (rsm.SSEnv{}) {
+				plog.Warningf("%s removing temp snapshot dir", n.id())
+				ssenv.MustRemoveTempDir()
+			}
+			return 0, nil
+		}
 		if saveAborted(err) {
 			plog.Warningf("%s save snapshot aborted, %v", n.id(), err)
 			ssenv.MustRemoveTempDir()
@@ -830,6 +862,10 @@ func (n *node) stream(sink pb.IChunkSink) error {
 	if sink != nil {
 		plog.Infof("%s requested to stream to %d", n.id(), sink.ToReplicaID())
 		if err := n.sm.Stream(sink); err != nil {
+			if n.handleUserStateMachineError(err) {
+				plog.Errorf("%s SM failed stream: %v", n.id(), err)
+				return nil
+			}
 			if !streamAborted(err) {
 				return errors.Wrapf(err, "%s stream failed", n.id())
 			}
@@ -849,6 +885,10 @@ func (n *node) recover(rec rsm.Task) (_ uint64, err error) {
 				plog.Warningf("%s aborted OpenOnDiskStateMachine", n.id())
 				return 0, nil
 			}
+			if n.handleUserStateMachineError(err) {
+				plog.Errorf("%s SM failed open: %v", n.id(), err)
+				return 0, nil
+			}
 			return 0, errors.Wrapf(err, "%s OpenOnDiskStateMachine failed", n.id())
 		}
 		if idx > 0 && rec.NewNode {
@@ -861,6 +901,10 @@ func (n *node) recover(rec rsm.Task) (_ uint64, err error) {
 			plog.Warningf("%s aborted recovery", n.id())
 			return 0, nil
 		}
+		if n.handleUserStateMachineError(err) {
+			plog.Errorf("%s SM failed recovery: %v", n.id(), err)
+			return 0, nil
+		}
 		return 0, errors.Wrapf(err, "%s recover failed", n.id())
 	}
 	if !pb.IsEmptySnapshot(ss) {
@@ -870,6 +914,10 @@ func (n *node) recover(rec rsm.Task) (_ uint64, err error) {
 		plog.Infof("%s recovered from %s", n.id(), n.ssid(ss.Index))
 		if n.OnDiskStateMachine() {
 			if err := n.sm.Sync(); err != nil {
+				if n.handleUserStateMachineError(err) {
+					plog.Errorf("%s SM sync after recover: %v", n.id(), err)
+					return 0, nil
+				}
 				return 0, errors.Wrapf(err, "%s sync failed", n.id())
 			}
 			if err := n.snapshotter.Shrink(ss.Index); err != nil {
@@ -916,7 +964,14 @@ func (n *node) recoverFromSnapshotDone() {
 }
 
 func (n *node) handleTask(ts []rsm.Task, es []sm.Entry) (rsm.Task, error) {
-	return n.sm.Handle(ts, es)
+	t, err := n.sm.Handle(ts, es)
+
+	if n.handleUserStateMachineError(err) {
+		plog.Errorf("%s SM handle task failed", n.id())
+		return rsm.Task{}, nil
+	}
+
+	return t, err
 }
 
 func (n *node) removeSnapshotFlagFile(index uint64) error {
@@ -1705,4 +1760,15 @@ func (n *node) millisecondSinceStart() uint64 {
 
 func (n *node) getRaftAddress() string {
 	return n.raftAddress
+}
+
+func (n *node) handleUserStateMachineError(err error) bool {
+	err = rsm.UnwrapUserSmError(err)
+	if err == nil {
+		return false
+	}
+
+	n.userStateMachineErr = err
+	n.requestRemoval()
+	return true
 }

--- a/nodehost_test.go
+++ b/nodehost_test.go
@@ -5448,3 +5448,404 @@ func TestSlowTestStressedSnapshotWorker(t *testing.T) {
 		}
 	}
 }
+
+func TestOnDiskSMOpenWithFailHandler(t *testing.T) {
+	fs := vfs.GetTestFS()
+	fakeDiskSM := tests.NewFakeDiskSM(0)
+	openErr := fmt.Errorf("open err")
+	fakeDiskSM.OpenErr.Store(&openErr)
+	handled := make(chan struct{})
+
+	to := &testOption{
+		updateConfig: func(c *config.Config) *config.Config {
+			c.FailHandler = func(err error) {
+				close(handled)
+				require.Equal(t, openErr, err)
+			}
+			return c
+		},
+		createOnDiskSM: func(uint64, uint64) sm.IOnDiskStateMachine {
+			return fakeDiskSM
+		},
+		tf: func(nh *NodeHost) {
+			select {
+			case <-handled:
+			case <-time.After(time.Second * 10):
+				require.Fail(t, "FailHandler not called")
+			}
+
+			_, ok := nh.getShard(1)
+			require.False(t, ok)
+		},
+		noElection: true,
+	}
+
+	runNodeHostTest(t, to, fs)
+}
+
+func TestOnDiskSMCloseWithFailHandler(t *testing.T) {
+	fs := vfs.GetTestFS()
+	fakeDiskSM := tests.NewFakeDiskSM(0)
+	closeErr := fmt.Errorf("close err")
+	fakeDiskSM.CloseErr.Store(&closeErr)
+	handled := make(chan struct{})
+
+	to := &testOption{
+		updateConfig: func(c *config.Config) *config.Config {
+			c.FailHandler = func(err error) {
+				close(handled)
+				require.Equal(t, closeErr, err)
+			}
+			return c
+		},
+		createOnDiskSM: func(uint64, uint64) sm.IOnDiskStateMachine {
+			return fakeDiskSM
+		},
+		tf: func(nh *NodeHost) {
+		},
+		at: func(nh *NodeHost) {
+			select {
+			case <-handled:
+			case <-time.After(time.Second * 10):
+				require.Fail(t, "FailHandler not called")
+			}
+		},
+	}
+
+	runNodeHostTest(t, to, fs)
+}
+
+func TestOnDiskSMUpdateWithFailHandler(t *testing.T) {
+	fs := vfs.GetTestFS()
+	fakeDiskSM := tests.NewFakeDiskSM(0)
+	updateErr := fmt.Errorf("update fail")
+	handled := make(chan struct{})
+	proposedCount := 0
+
+	var smPointer atomic.Pointer[tests.FakeDiskSM]
+	smPointer.Store(fakeDiskSM)
+
+	var timeout time.Duration
+
+	to := &testOption{
+		updateConfig: func(c *config.Config) *config.Config {
+			c.FailHandler = func(err error) {
+				require.Equal(t, updateErr, err)
+				close(handled)
+			}
+			return c
+		},
+		createOnDiskSM: func(uint64, uint64) sm.IOnDiskStateMachine {
+			return smPointer.Load()
+		},
+		tf: func(nh *NodeHost) {
+			timeout = pto(nh)
+
+			for i := 0; i < 9; i++ {
+				ctx, cancel := context.WithTimeout(context.Background(), timeout)
+				sess := nh.GetNoOPSession(1)
+				_, err := nh.SyncPropose(ctx, sess, make([]byte, 1))
+				cancel()
+				require.NoError(t, err)
+				proposedCount++
+			}
+
+			fakeDiskSM.UpdateErr.Store(&updateErr)
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			sess := nh.GetNoOPSession(1)
+			_, err := nh.SyncPropose(ctx, sess, make([]byte, 1))
+			cancel()
+			proposedCount++ // committed but not applied
+
+			// Update fail, shard closes
+			if !errors.Is(err, ErrShardClosed) && !errors.Is(err, ErrShardNotFound) {
+				require.Fail(t, "SyncPropose: unexpected err: %v", err)
+			}
+
+			select {
+			case <-handled:
+			case <-time.After(time.Second * 5):
+				require.Fail(t, "FailHandler not called")
+			}
+
+			_, ok := nh.getShard(1)
+			require.False(t, ok)
+
+			// "fix" replica and restart
+			fakeDiskSM := tests.NewFakeDiskSM(0)
+			smPointer.Store(fakeDiskSM)
+		},
+		restartNodeHost: true,
+		rf: func(nh *NodeHost) {
+			waitForLeaderToBeElected(t, nh, 1)
+			appliedCount := readFakeDiskSMState(t, nh, 1, timeout)
+			require.EqualValues(t, proposedCount, appliedCount, "replica did not reapply last entry")
+		},
+	}
+
+	runNodeHostTest(t, to, fs)
+}
+
+func TestOnDiskSMPrepareSnapshotWithFailHandler(t *testing.T) {
+	fs := vfs.GetTestFS()
+	fakeDiskSM := tests.NewFakeDiskSM(0)
+	prepareSnapshotErr := fmt.Errorf("prepare snapshot fail")
+	fakeDiskSM.PrepareSnapshotErr.Store(&prepareSnapshotErr)
+	handled := make(chan struct{})
+
+	to := &testOption{
+		updateConfig: func(c *config.Config) *config.Config {
+			c.FailHandler = func(err error) {
+				close(handled)
+				require.Equal(t, prepareSnapshotErr, err)
+			}
+			return c
+		},
+		createOnDiskSM: func(uint64, uint64) sm.IOnDiskStateMachine {
+			return fakeDiskSM
+		},
+		tf: func(nh *NodeHost) {
+			_, err := requestSnapshot(t, nh, 1, fs)
+
+			if !errors.Is(err, ErrRejected) && !errors.Is(err, ErrShardClosed) {
+				require.Fail(t, "SyncRequestSnapshot unexpected err: %v", err)
+			}
+
+			select {
+			case <-handled:
+			case <-time.After(time.Second * 5):
+				require.Fail(t, "FailHandler not called")
+			}
+
+			_, ok := nh.getShard(1)
+			require.False(t, ok)
+		},
+	}
+
+	runNodeHostTest(t, to, fs)
+}
+
+func TestOnDiskSMSaveSnapshotWithFailHandler(t *testing.T) {
+	fs := vfs.GetTestFS()
+	fakeDiskSM := tests.NewFakeDiskSM(0)
+	saveSnapshotErr := fmt.Errorf("save snapshot fail")
+	fakeDiskSM.SaveSnapshotErr.Store(&saveSnapshotErr)
+	handled := make(chan struct{})
+
+	to := &testOption{
+		updateConfig: func(c *config.Config) *config.Config {
+			c.FailHandler = func(err error) {
+				close(handled)
+				require.Equal(t, saveSnapshotErr, err)
+			}
+			return c
+		},
+		createOnDiskSM: func(uint64, uint64) sm.IOnDiskStateMachine {
+			return fakeDiskSM
+		},
+		tf: func(nh *NodeHost) {
+			_, err := requestSnapshot(t, nh, 1, fs)
+
+			if !errors.Is(err, ErrShardClosed) {
+				require.Fail(t, "SyncRequestSnapshot unexpected err: %v", err)
+			}
+
+			select {
+			case <-handled:
+			case <-time.After(time.Second * 5):
+				require.Fail(t, "FailHandler not called", err)
+			}
+
+			_, ok := nh.getShard(1)
+			require.False(t, ok)
+		},
+	}
+
+	runNodeHostTest(t, to, fs)
+}
+
+func requestSnapshot(t *testing.T, nh *NodeHost, shardID uint64, fs vfs.IFS) (uint64, error) {
+	sspath := "exported_snapshot_safe_to_delete"
+	err := fs.RemoveAll(sspath)
+	require.NoError(t, err)
+	err = fs.MkdirAll(sspath, 0755)
+	require.NoError(t, err)
+
+	defer func() {
+		err := fs.RemoveAll(sspath)
+		require.NoError(t, err)
+	}()
+
+	opt := SnapshotOption{
+		ExportPath: sspath,
+		Exported:   true,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	return nh.SyncRequestSnapshot(ctx, shardID, opt)
+}
+
+func TestOnDiskSMSnapshotSyncWithFailHandler(t *testing.T) {
+	fs := vfs.GetTestFS()
+	fakeDiskSM := tests.NewFakeDiskSM(0)
+	handled := make(chan struct{})
+	syncErr := fmt.Errorf("sync err")
+	snapshotEntries := uint64(10)
+
+	var smPointer atomic.Pointer[tests.FakeDiskSM]
+	smPointer.Store(fakeDiskSM)
+
+	var timeout time.Duration
+
+	to := &testOption{
+		updateConfig: func(c *config.Config) *config.Config {
+			c.FailHandler = func(err error) {
+				close(handled)
+				require.Equal(t, syncErr, err)
+			}
+			c.SnapshotEntries = snapshotEntries
+			return c
+		},
+		createOnDiskSM: func(uint64, uint64) sm.IOnDiskStateMachine {
+			return smPointer.Load()
+		},
+		tf: func(nh *NodeHost) {
+			timeout = pto(nh)
+			fakeDiskSM.SyncErr.Store(&syncErr)
+
+			session := nh.GetNoOPSession(1)
+
+			for i := 0; i < int(snapshotEntries); i++ {
+				_, err := nh.Propose(session, []byte("test-data"), timeout)
+				if errors.Is(err, ErrShardClosed) || errors.Is(err, ErrShardNotFound) {
+					break
+				}
+				require.NoError(t, err)
+			}
+
+			select {
+			case <-time.After(time.Second * 10):
+				require.Fail(t, "FailHandler not called")
+			case <-handled:
+			}
+
+			_, ok := nh.getShard(1)
+			require.False(t, ok)
+
+			// "fix" replica and restart
+			fakeDiskSM := tests.NewFakeDiskSM(0)
+			smPointer.Store(fakeDiskSM)
+		},
+		restartNodeHost: true,
+		rf: func(nh *NodeHost) {
+			waitForLeaderToBeElected(t, nh, 1)
+			appliedCount := readFakeDiskSMState(t, nh, 1, timeout)
+
+			require.Equal(t, snapshotEntries, appliedCount, "replica did not recover from sync failure")
+		},
+	}
+
+	runNodeHostTest(t, to, fs)
+}
+
+func TestOnDiskSMRecoverWithFailHandler(t *testing.T) {
+	fs := vfs.GetTestFS()
+	tf := func(t *testing.T, nh1 *NodeHost, nh2 *NodeHost) {
+		rc := config.Config{
+			ShardID:            1,
+			ReplicaID:          1,
+			ElectionRTT:        3,
+			HeartbeatRTT:       1,
+			CheckQuorum:        true,
+			SnapshotEntries:    5,
+			CompactionOverhead: 2,
+		}
+		sm1 := tests.NewFakeDiskSM(0)
+		sm1.SetAborted()
+		peers := make(map[uint64]string)
+		peers[1] = nodeHostTestAddr1
+		newSM := func(uint64, uint64) sm.IOnDiskStateMachine {
+			return sm1
+		}
+		err := nh1.StartOnDiskReplica(peers, false, newSM, rc)
+		require.NoError(t, err)
+		waitForLeaderToBeElected(t, nh1, 1)
+		session := nh1.GetNoOPSession(1)
+		proposalCount := 10
+		pto := pto(nh1)
+		for i := 0; i < proposalCount; i++ {
+			ctx, cancel := context.WithTimeout(context.Background(), pto)
+			_, err := nh1.SyncPropose(ctx, session, []byte("test-data"))
+			cancel()
+			require.NoError(t, err)
+		}
+
+		lpto := lpto(nh1)
+		ctx, cancel := context.WithTimeout(context.Background(), lpto)
+		err = nh1.SyncRequestAddReplica(ctx, 1, 2, nodeHostTestAddr2, 0)
+		cancel()
+		require.NoError(t, err)
+		sm1.ClearAborted()
+
+		recoverErr := fmt.Errorf("recover fail")
+		handled := make(chan struct{})
+		r2c := config.Config{
+			ShardID:            1,
+			ReplicaID:          2,
+			ElectionRTT:        3,
+			HeartbeatRTT:       1,
+			CheckQuorum:        true,
+			SnapshotEntries:    5,
+			CompactionOverhead: 2,
+			FailHandler: func(err error) {
+				close(handled)
+				require.Equal(t, recoverErr, err)
+			},
+		}
+
+		sm2 := tests.NewFakeDiskSM(0)
+		sm2.RecoverErr.Store(&recoverErr)
+		sm2.SetAborted()
+
+		var sm2Pointer atomic.Pointer[tests.FakeDiskSM]
+		sm2Pointer.Store(sm2)
+		newSM2 := func(uint64, uint64) sm.IOnDiskStateMachine {
+			return sm2Pointer.Load()
+		}
+		err = nh2.StartOnDiskReplica(nil, true, newSM2, r2c)
+		require.NoError(t, err)
+		waitForLeaderToBeElected(t, nh2, 1)
+		select {
+		case <-time.After(time.Second * 5):
+			require.Fail(t, "FailHandler not called")
+		case <-handled:
+		}
+
+		_, ok := nh2.getShard(1)
+		require.False(t, ok)
+
+		// "fix" replica and start again
+		reloadedSm := tests.NewFakeDiskSM(uint64(proposalCount - 1))
+		sm2Pointer.Store(reloadedSm)
+		err = nh2.StartOnDiskReplica(nil, true, newSM2, r2c)
+		require.NoError(t, err)
+
+		waitForLeaderToBeElected(t, nh2, 1)
+
+		appliedCount := readFakeDiskSMState(t, nh2, 1, pto)
+		require.EqualValues(t, proposalCount, appliedCount, "recovery is incomplete")
+	}
+	twoFakeDiskNodeHostTest(t, tf, fs)
+}
+
+func readFakeDiskSMState(t *testing.T, nh *NodeHost, shard uint64, timeout time.Duration) uint64 {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	result, err := nh.SyncRead(ctx, shard, nil)
+	cancel()
+
+	require.NoError(t, err)
+
+	count := binary.LittleEndian.Uint64(result.([]byte))
+
+	return count
+}

--- a/nodehost_test.go
+++ b/nodehost_test.go
@@ -5458,7 +5458,7 @@ func TestOnDiskSMOpenWithFailHandler(t *testing.T) {
 
 	to := &testOption{
 		updateConfig: func(c *config.Config) *config.Config {
-			c.FailHandler = func(err error) {
+			c.FaultHandler = func(err error) {
 				close(handled)
 				require.Equal(t, openErr, err)
 			}
@@ -5492,7 +5492,7 @@ func TestOnDiskSMCloseWithFailHandler(t *testing.T) {
 
 	to := &testOption{
 		updateConfig: func(c *config.Config) *config.Config {
-			c.FailHandler = func(err error) {
+			c.FaultHandler = func(err error) {
 				close(handled)
 				require.Equal(t, closeErr, err)
 			}
@@ -5529,7 +5529,7 @@ func TestOnDiskSMUpdateWithFailHandler(t *testing.T) {
 
 	to := &testOption{
 		updateConfig: func(c *config.Config) *config.Config {
-			c.FailHandler = func(err error) {
+			c.FaultHandler = func(err error) {
 				require.Equal(t, updateErr, err)
 				close(handled)
 			}
@@ -5595,7 +5595,7 @@ func TestOnDiskSMPrepareSnapshotWithFailHandler(t *testing.T) {
 
 	to := &testOption{
 		updateConfig: func(c *config.Config) *config.Config {
-			c.FailHandler = func(err error) {
+			c.FaultHandler = func(err error) {
 				close(handled)
 				require.Equal(t, prepareSnapshotErr, err)
 			}
@@ -5634,7 +5634,7 @@ func TestOnDiskSMSaveSnapshotWithFailHandler(t *testing.T) {
 
 	to := &testOption{
 		updateConfig: func(c *config.Config) *config.Config {
-			c.FailHandler = func(err error) {
+			c.FaultHandler = func(err error) {
 				close(handled)
 				require.Equal(t, saveSnapshotErr, err)
 			}
@@ -5699,7 +5699,7 @@ func TestOnDiskSMSnapshotSyncWithFailHandler(t *testing.T) {
 
 	to := &testOption{
 		updateConfig: func(c *config.Config) *config.Config {
-			c.FailHandler = func(err error) {
+			c.FaultHandler = func(err error) {
 				close(handled)
 				require.Equal(t, syncErr, err)
 			}
@@ -5797,7 +5797,7 @@ func TestOnDiskSMRecoverWithFailHandler(t *testing.T) {
 			CheckQuorum:        true,
 			SnapshotEntries:    5,
 			CompactionOverhead: 2,
-			FailHandler: func(err error) {
+			FaultHandler: func(err error) {
 				close(handled)
 				require.Equal(t, recoverErr, err)
 			},


### PR DESCRIPTION
Context in this issue https://github.com/lni/dragonboat/issues/381.
In short: I have my state machines on different disks, and I need the ability to stop one if a disk fails. Currently, there’s no way to do that — any error returned from the SM leads to a panic inside Dragonboat. @kevburnsjr proposed adding an error handler to the node: to stop the replica on error and then call the handler out of band. Here are the changes:

* Added the `FailHandler` function in the node config. The proposed name in the issue was `Recover`, but it’s a bit confusing, in my opinion.
* Errors returned from `IOnDiskStateMachine` are wrapped.
* Changes to the node:
  * The node checks if the error originated in the user’s state machine and if a FailHandler is present. If so, the node does requestRemoval and saves the error. The node returns no error to the engine in this case. Engine workers shouldn’t start new tasks on the node since it is `stopped()`.
  * `FailHandler` is called with the saved error once the node is fully offloaded.
* Added test cases for errors from all SM methods.

I haven’t tested this change in production yet; I’ll report once I do.

Please let me know what you think.