### PR TITLE
feat(tools): add logdump tool to scan and inspect raft log (pebbledb based)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ coverage.txt
 gitversion.go
 drummer-data
 nodehost-data
+/tools/logdump/logdump
+/logdump

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/lni/goutils v1.3.0
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/net v0.15.0 // indirect
+	google.golang.org/protobuf v1.23.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/internal/logdb/kv/pebble/nolock_fs.go
+++ b/internal/logdb/kv/pebble/nolock_fs.go
@@ -1,0 +1,143 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pebble
+
+import (
+	"io"
+	"os"
+
+	pvfs "github.com/cockroachdb/pebble/vfs"
+
+	"github.com/lni/dragonboat/v3/config"
+	"github.com/lni/dragonboat/v3/internal/logdb/kv"
+	"github.com/lni/dragonboat/v3/internal/vfs"
+)
+
+// noLockFS is a filesystem wrapper that bypasses file locking for non-blocking
+// read-only access. It implements the pebble/vfs.FS interface but returns
+// a no-op closer for Lock operations, allowing read-only Pebble instances to
+// open databases that are actively locked by running NodeHost instances.
+type NoLockFS struct {
+	fs pvfs.FS
+}
+
+var _ pvfs.FS = (*NoLockFS)(nil)
+
+// NewNoLockFS creates a new pebble/vfs.FS instance that bypasses locking.
+func NewNoLockFS(fs vfs.IFS) pvfs.FS {
+	return &NoLockFS{fs: vfs.NewPebbleFS(fs)}
+}
+
+// Create creates the named file for writing, truncating it if it already exists.
+func (n *NoLockFS) Create(name string) (pvfs.File, error) {
+	return n.fs.Create(name)
+}
+
+// Link creates newname as a hard link to the oldname file.
+func (n *NoLockFS) Link(oldname, newname string) error {
+	return n.fs.Link(oldname, newname)
+}
+
+// Open opens the named file for reading.
+func (n *NoLockFS) Open(name string, opts ...pvfs.OpenOption) (pvfs.File, error) {
+	return n.fs.Open(name, opts...)
+}
+
+// OpenDir opens the named directory for syncing.
+func (n *NoLockFS) OpenDir(name string) (pvfs.File, error) {
+	return n.fs.OpenDir(name)
+}
+
+// Remove removes the named file or directory.
+func (n *NoLockFS) Remove(name string) error {
+	return n.fs.Remove(name)
+}
+
+// RemoveAll removes the named file or directory and any children it contains.
+func (n *NoLockFS) RemoveAll(name string) error {
+	return n.fs.RemoveAll(name)
+}
+
+// Rename renames a file.
+func (n *NoLockFS) Rename(oldname, newname string) error {
+	return n.fs.Rename(oldname, newname)
+}
+
+// ReuseForWrite attempts to reuse the file with oldname.
+func (n *NoLockFS) ReuseForWrite(oldname, newname string) (pvfs.File, error) {
+	return n.fs.ReuseForWrite(oldname, newname)
+}
+
+// MkdirAll creates a directory and all necessary parents.
+func (n *NoLockFS) MkdirAll(dir string, perm os.FileMode) error {
+	return n.fs.MkdirAll(dir, perm)
+}
+
+// Lock returns a no-op closer, bypassing file locking for read-only access.
+// This allows opening databases that are actively locked by running instances.
+func (n *NoLockFS) Lock(name string) (io.Closer, error) {
+	// Return a no-op closer that does nothing when closed
+	return &noOpCloser{}, nil
+}
+
+// List returns a listing of the given directory.
+func (n *NoLockFS) List(dir string) ([]string, error) {
+	return n.fs.List(dir)
+}
+
+// Stat returns an os.FileInfo describing the named file.
+func (n *NoLockFS) Stat(name string) (os.FileInfo, error) {
+	return n.fs.Stat(name)
+}
+
+// PathBase returns the last element of path.
+func (n *NoLockFS) PathBase(path string) string {
+	return n.fs.PathBase(path)
+}
+
+// PathJoin joins any number of path elements into a single path.
+func (n *NoLockFS) PathJoin(elem ...string) string {
+	return n.fs.PathJoin(elem...)
+}
+
+// PathDir returns all but the last element of path.
+func (n *NoLockFS) PathDir(path string) string {
+	return n.fs.PathDir(path)
+}
+
+// GetFreeSpace returns the amount of free disk space for the filesystem.
+func (n *NoLockFS) GetFreeSpace(path string) (uint64, error) {
+	return n.fs.GetFreeSpace(path)
+}
+
+// noOpCloser is a Closer that does nothing when Close() is called.
+type noOpCloser struct{}
+
+func (n *noOpCloser) Close() error {
+	return nil
+}
+
+// PebbleReadOnlyNoLockKVStore creates a read-only pebble-based IKVStore instance.
+// Implementation of logdb.kvFactory.
+func PebbleReadOnlyNoLockKVStore(config config.LogDBConfig,
+	callback kv.LogDBCallback,
+	dir string, wal string, fs vfs.IFS) (kv.IKVStore, error) {
+	if fs != vfs.DefaultFS {
+		_, isErrorFS := fs.(*vfs.ErrorFS)
+		_, isMemFS := fs.(*vfs.MemFS)
+		if !isErrorFS && !isMemFS {
+			panic("invalid fs")
+		}
+	}
+	return NewReadOnlyKVStore(config, dir, wal, NewNoLockFS(fs))
+}

--- a/internal/logdb/kv/pebble/readonly.go
+++ b/internal/logdb/kv/pebble/readonly.go
@@ -1,0 +1,158 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pebble
+
+import (
+	"github.com/cockroachdb/pebble"
+	pvfs "github.com/cockroachdb/pebble/vfs"
+
+	"github.com/lni/dragonboat/v3/config"
+	"github.com/lni/dragonboat/v3/internal/logdb/kv"
+	"github.com/lni/dragonboat/v3/internal/vfs"
+)
+
+// readOnlyKV is a read-only pebble based IKVStore type.
+type readOnlyKV struct {
+	*KV
+}
+
+var _ kv.IKVStore = (*readOnlyKV)(nil)
+
+// NewReadOnlyKVStore opens an existing Pebble DB in read-only mode.
+// fs is a PebbleDB virtual file system. It can be obtained by calling
+// vfs.NewPebbleFS() with a Dragonboat virtual file system or NewNoLockFS().
+func NewReadOnlyKVStore(config config.LogDBConfig,
+	dir string, walDir string, fs pvfs.FS) (kv.IKVStore, error) {
+
+	if config.IsEmpty() {
+		panic("invalid LogDBConfig")
+	}
+	blockSize := int(config.KVBlockSize)
+	writeBufferSize := int(config.KVWriteBufferSize)
+	maxWriteBufferNumber := int(config.KVMaxWriteBufferNumber)
+	l0FileNumCompactionTrigger := int(config.KVLevel0FileNumCompactionTrigger)
+	l0StopWritesTrigger := int(config.KVLevel0StopWritesTrigger)
+	maxBytesForLevelBase := int64(config.KVMaxBytesForLevelBase)
+	targetFileSizeBase := int64(config.KVTargetFileSizeBase)
+	cacheSize := int64(config.KVLRUCacheSize)
+	levelSizeMultiplier := int64(config.KVTargetFileSizeMultiplier)
+	numOfLevels := int64(config.KVNumOfLevels)
+	lopts := make([]pebble.LevelOptions, 0)
+	sz := targetFileSizeBase
+	for l := int64(0); l < numOfLevels; l++ {
+		opt := pebble.LevelOptions{
+			Compression:    pebble.NoCompression,
+			BlockSize:      blockSize,
+			TargetFileSize: sz,
+		}
+		sz = sz * levelSizeMultiplier
+		lopts = append(lopts, opt)
+	}
+	if inMonkeyTesting {
+		writeBufferSize = 1024 * 1024 * 4
+	}
+	cache := pebble.NewCache(cacheSize)
+	ro := &pebble.IterOptions{}
+	opts := &pebble.Options{
+		Levels:                      lopts,
+		MaxManifestFileSize:         maxLogFileSize,
+		MemTableSize:                writeBufferSize,
+		MemTableStopWritesThreshold: maxWriteBufferNumber,
+		LBaseMaxBytes:               maxBytesForLevelBase,
+		L0CompactionThreshold:       l0FileNumCompactionTrigger,
+		L0StopWritesThreshold:       l0StopWritesTrigger,
+		Cache:                       cache,
+		FS:                          fs,
+		ReadOnly:                    true,
+		Logger:                      PebbleLogger,
+	}
+	kv := &KV{
+		ro:     ro,
+		opts:   opts,
+		config: config,
+		dbSet:  make(chan struct{}),
+	}
+	if len(walDir) > 0 {
+		opts.WALDir = walDir
+	}
+
+	pdb, err := pebble.Open(dir, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	cache.Unref()
+	kv.db = pdb
+
+	return &readOnlyKV{kv}, nil
+}
+
+// Name returns the IKVStore type name.
+func (r *readOnlyKV) Name() string {
+	return "pebble-readonly"
+}
+
+// Close closes the read-only KV store.
+func (r *readOnlyKV) Close() error {
+	return r.db.Close()
+}
+
+// SaveValue is not supported in read-only mode.
+func (r *readOnlyKV) SaveValue(key []byte, value []byte) error {
+	panic("read-only store: SaveValue not supported")
+}
+
+// DeleteValue is not supported in read-only mode.
+func (r *readOnlyKV) DeleteValue(key []byte) error {
+	panic("read-only store: DeleteValue not supported")
+}
+
+// GetWriteBatch is not supported in read-only mode.
+func (r *readOnlyKV) GetWriteBatch() kv.IWriteBatch {
+	panic("read-only store: GetWriteBatch not supported")
+}
+
+// CommitWriteBatch is not supported in read-only mode.
+func (r *readOnlyKV) CommitWriteBatch(wb kv.IWriteBatch) error {
+	panic("read-only store: CommitWriteBatch not supported")
+}
+
+// BulkRemoveEntries is not supported in read-only mode.
+func (r *readOnlyKV) BulkRemoveEntries(fk []byte, lk []byte) error {
+	panic("read-only store: BulkRemoveEntries not supported")
+}
+
+// CompactEntries is a no-op in read-only mode.
+func (r *readOnlyKV) CompactEntries(fk []byte, lk []byte) error {
+	return nil
+}
+
+// FullCompaction is a no-op in read-only mode.
+func (r *readOnlyKV) FullCompaction() error {
+	return nil
+}
+
+// PebbleReadOnlyKVStore creates a read-only pebble-based IKVStore instance.
+// Implementation of logdb.kvFactory.
+func PebbleReadOnlyKVStore(config config.LogDBConfig,
+	callback kv.LogDBCallback,
+	dir string, wal string, fs vfs.IFS) (kv.IKVStore, error) {
+	if fs != vfs.DefaultFS {
+		_, isErrorFS := fs.(*vfs.ErrorFS)
+		_, isMemFS := fs.(*vfs.MemFS)
+		if !isErrorFS && !isMemFS {
+			panic("invalid fs")
+		}
+	}
+	return NewReadOnlyKVStore(config, dir, wal, vfs.NewPebbleFS(fs))
+}

--- a/internal/logdb/readonly.go
+++ b/internal/logdb/readonly.go
@@ -1,0 +1,116 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logdb
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/cockroachdb/errors"
+	"github.com/lni/goutils/syncutil"
+
+	"github.com/lni/dragonboat/v3/config"
+	"github.com/lni/dragonboat/v3/internal/fileutil"
+	"github.com/lni/dragonboat/v3/internal/server"
+	"github.com/lni/dragonboat/v3/internal/vfs"
+	"github.com/lni/dragonboat/v3/raftio"
+	"github.com/lni/dragonboat/v3/raftpb"
+)
+
+// OpenReadOnlyLogDB opens a Dragonboat LogDB in read-only mode.
+// It discovers logdb-N shard directories within dir, auto-detects the
+// entry format (plain vs batched), and returns a raftio.ILogDB suitable
+// for forensics and inspection.
+func OpenReadOnlyLogDB(cfg config.LogDBConfig,
+	dir, wal string, fs vfs.IFS, f kvFactory) (raftio.ILogDB, error) {
+
+	const flagFilename = "dragonboat.ds"
+
+	s := raftpb.RaftDataStatus{}
+	if err := fileutil.GetFlagFileContent(dir, flagFilename, &s, fs); err != nil {
+		return nil, errors.Wrapf(err, "failed to read %s", path.Join(dir, flagFilename))
+	}
+	cfg.Shards = s.LogdbShardCount
+
+	nodeHostCfg := config.NodeHostConfig{
+		NodeHostDir: dir,
+		WALDir:      wal,
+	}
+	env, err := server.NewEnv(nodeHostCfg, fs)
+	if err != nil {
+		return nil, errors.Wrap(err, "new env")
+	}
+	env.SetHostname(s.Hostname)
+
+	ddir, dwal := env.GetLogDBDirs(s.DeploymentId)
+
+	shards := make([]*db, 0)
+	closeAll := func(all []*db) {
+		for _, s := range all {
+			s.close()
+		}
+	}
+	for i := uint64(0); i < s.LogdbShardCount; i++ {
+		dir := path.Join(ddir, fmt.Sprintf("logdb-%d", i))
+		wal := path.Join(dwal, fmt.Sprintf("logdb-%d", i))
+
+		batched, err := detectBatchedEntryFormat(cfg, dir, wal, fs, f)
+		if err != nil {
+			closeAll(shards)
+			return nil, errors.Wrapf(err, "failed to detect entry format for shard %d", i)
+		}
+
+		s, err := openRDB(cfg, nil, dir, wal, batched, fs, f)
+		if err != nil {
+			closeAll(shards)
+			return nil, err
+		}
+		shards = append(shards, s)
+	}
+
+	// see OpenShardedDB for why we use StepWorkerCount here in Capacity position.
+	partitioner := server.NewDoubleFixedPartitioner(s.StepWorkerCount, s.LogdbShardCount)
+	return &ShardedDB{
+		config:      cfg,
+		shards:      shards,
+		partitioner: partitioner,
+		stopper:     syncutil.NewStopper(),
+	}, nil
+}
+
+func detectBatchedEntryFormat(cfg config.LogDBConfig, dir, wal string, fs vfs.IFS, f kvFactory) (bool, error) {
+	kvs, err := f(cfg, nil, dir, wal, fs)
+	if err != nil {
+		return false, err
+	}
+	defer kvs.Close()
+
+	batched, err := hasEntryRecord(kvs, true)
+	if err != nil {
+		return false, err
+	}
+	if batched {
+		return true, nil
+	}
+
+	plain, err := hasEntryRecord(kvs, false)
+	if err != nil {
+		return false, err
+	}
+	if plain {
+		return false, nil
+	}
+
+	// No entry records found — default to batched (the newer format).
+	return true, nil
+}

--- a/internal/server/environment.go
+++ b/internal/server/environment.go
@@ -105,6 +105,11 @@ func NewEnv(nhConfig config.NodeHostConfig, fs vfs.IFS) (*Env, error) {
 	return s, nil
 }
 
+// SetHostname sets the hostname to hostname.
+func (env *Env) SetHostname(hostname string) {
+	env.hostname = hostname
+}
+
 // Stop stops the environment.
 func (env *Env) Stop() {
 	for _, fl := range env.flocks {

--- a/tools/logdump/README.md
+++ b/tools/logdump/README.md
@@ -1,0 +1,196 @@
+# logdump — Dragonboat RAFT Log Inspection Tool
+
+A read-only CLI forensics tool for inspecting Dragonboat v3 LogDB (Pebble) data
+on disk. Safely reads live data alongside a running NodeHost — no LOCK file
+acquisition, no writes to the data directory.
+
+## Build
+
+```bash
+go build -o logdump ./tools/logdump/
+```
+
+No CGO required. Pebble-only.
+
+## Commands
+
+### `list` — show available clusters and nodes
+
+Scans the LogDB and prints a summary table with RAFT state, entry counts,
+snapshot counts, and bootstrap info for every (cluster, node) pair.
+
+```
+logdump list <data-dir> [--cluster N] [--node N]
+```
+
+#### Example
+
+```bash
+$ logdump list /var/dragonboat/nodehost
+```
+
+```
+NODES IN: /var/dragonboat/nodehost
+
+CLUSTER  NODE  TERM  VOTE  COMMIT  ENTRIES  RANGE        SNAPSHOTS  BOOTSTRAP
+1        1     7     1     1523    1523     [1..1523]    1          join=false, 3 addrs, sm=RegularStateMachine
+1        2     7     1     1523    1520     [4..1523]    0          join=true, 3 addrs, sm=RegularStateMachine
+2        1     3     1     89      89       [1..89]      1          join=false, 1 addrs, sm=OnDiskStateMachine
+```
+
+**Columns:**
+
+| Column | Description |
+|--------|-------------|
+| `CLUSTER` | Cluster ID |
+| `NODE` | Node ID within the cluster |
+| `TERM` | Current RAFT term |
+| `VOTE` | Node this node voted for in the current term |
+| `COMMIT` | Commit index |
+| `ENTRIES` | Number of log entries stored |
+| `RANGE` | Entry index range `[first..last]` — a gap at the start (first > 1) means entries were compacted by snapshots |
+| `SNAPSHOTS` | Count of stored snapshots |
+| `BOOTSTRAP` | Bootstrap summary: whether the node joined, address count, and state machine type |
+
+Filter with `--cluster` and/or `--node` to narrow the output:
+
+```bash
+$ logdump list /var/dragonboat/nodehost --cluster 1
+$ logdump list /var/dragonboat/nodehost --cluster 1 --node 2
+```
+
+---
+
+### `get` — pretty-print RAFT log entries
+
+Fetches and displays the RAFT state, snapshots, and log entries for a specific
+node in the requested index range.
+
+```
+logdump get <data-dir> --cluster N --node N [flags]
+```
+
+#### Table format (default)
+
+```bash
+$ logdump get /var/dragonboat/nodehost --cluster 1 --node 2 --from 100 --to 110
+```
+
+```
+── state: cluster=1 node=2 ──
+Term: 7, Vote: 1, Commit: 1523
+
+── snapshots ──
+INDEX  TERM  MEMBERS
+1500   7     3 addrs
+
+── entries ──
+INDEX  TERM  TYPE               KEY  CLIENT  SERIES  RESPTO  CMD
+100    7     ApplicationEntry   42   1001    5       99      a3f2c801a9b7... (16 B)
+101    7     ConfigChangeEntry  0    0       0       0       node_id:3 address:"node3:63000"
+102    7     ApplicationEntry   43   1001    6       99      b4e1d92f3c01... (28 B)
+103    8     ApplicationEntry   44   1002    1       0       hello world
+──     8     MetadataEntry      0    0       0       0       (empty)
+──     8     EncodedEntry       0    0       0       0       <encoded, 64 B>
+
+6 entries shown (limit 100, range [100, 110)), total entries in log: 1523
+```
+
+**Section layout:**
+
+1. **`── state ──`** — current term, vote, and commit index
+2. **`── snapshots ──`** — snapshots within the range (hidden when empty)
+3. **`── entries ──`** — log entries table
+
+**Entry table columns:**
+
+| Column | Description |
+|--------|-------------|
+| `INDEX` | Log index |
+| `TERM` | RAFT term when the entry was proposed |
+| `TYPE` | Entry type: `ApplicationEntry`, `ConfigChangeEntry`, `MetadataEntry`, `EncodedEntry` |
+| `KEY` | Session key for session-managed entries |
+| `CLIENT` | Client ID |
+| `SERIES` | Series ID (proposal sequence number) |
+| `RESPTO` | RespondedTo (last index client has seen applied) |
+| `CMD` | Payload — see format rules below |
+
+**CMD formatting (auto-detected):**
+
+| Condition | Display |
+|-----------|---------|
+| Config change with printable text | Decoded inline: `node_id:3 address:"node3:63000"` |
+| New session request | `(new session)` |
+| End of session request | `(end session)` |
+| No-op session (empty payload) | `(no-op)` |
+| Truly empty entry | `(empty)` |
+| Short printable text (≤ 40 B) | Shown inline: `hello world` |
+| Binary payload | Hex dump of first 6 bytes + total size: `a3f2c801a9b7... (16 B)` |
+
+**Ranges** are half-open `[from, to)` — `from` is inclusive, `to` is exclusive.
+
+**Internal entries** (`MetadataEntry`, `EncodedEntry`) are visually dimmed with
+a `── ` prefix.
+
+**Footer** reports how many entries were shown, the limit, the requested range,
+and total entries in the log.
+
+#### Single entry shortcut
+
+Use `--index N` as a shortcut for `--from N --to N+1`:
+
+```bash
+$ logdump get /var/dragonboat/nodehost --cluster 1 --node 2 --index 42
+```
+
+#### JSON format
+
+Use `--format json` for machine-readable output:
+
+```bash
+$ logdump get /var/dragonboat/nodehost --cluster 1 --node 2 --index 42 --format json
+```
+
+```json
+{"cluster_id":1,"node_id":2,"state":{"Term":7,"Vote":1,"Commit":1523},"snapshots":[],"entries":[{"index":42,"term":7,"type":"ApplicationEntry","key":15,"client_id":1001,"series_id":3,"responded_to":41,"cmd":"48656c6c6f2c20576f726c6421"}],"from":42,"to":43,"limit":100,"first_index":4,"last_index":1523,"entry_count":1520}
+```
+
+## Flags
+
+### `list` flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--cluster` | uint64 | `0` (all) | Filter by cluster ID |
+| `--node` | uint64 | `0` (all) | Filter by node ID |
+
+### `get` flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--cluster` | uint64 | `0` | **Required.** Cluster ID |
+| `--node` | uint64 | `0` | **Required.** Node ID |
+| `--from` | uint64 | first available | Start index (inclusive) |
+| `--to` | uint64 | last+1 | End index (exclusive) |
+| `--index` | uint64 | — | Single entry shortcut (`--from N --to N+1`) |
+| `--limit` | uint64 | `100` | Max entries to display (`0` = unlimited) |
+| `--format` | string | `table` | Output format: `table` or `json` |
+
+## Safety
+
+- **Read-only** — opens Pebble databases with `Options{ReadOnly: true}`, no LOCK
+  file is acquired. Safe to run alongside a live NodeHost.
+- **No writes** — all write methods panic. The tool cannot modify the data
+  directory.
+- **Panic recovery** — unexpected internal panics are caught at the top level
+  with a stack trace printed to stderr (exit code 2).
+
+## Limitations
+
+- **Pebble only.** RocksDB-based LogDB stores are not supported.
+- **Shard partitioner mismatch.** The read path uses `FixedPartitioner`
+  (`clusterID % logDBShards`) while production writes may use
+  `DoubleFixedPartitioner` (`(clusterID % execShards) % logDBShards`). This
+  only affects deployments where `ExecShards < LogDBShards` (rare).
+- **`--index 0` is silently ignored** — the zero value is indistinguishable from
+  "not set". Use `--from 0 --to 1` if you need index 0.

--- a/tools/logdump/config_test.go
+++ b/tools/logdump/config_test.go
@@ -1,0 +1,192 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+func TestNewIOConfig(t *testing.T) {
+	ioConfig := NewIOConfig()
+	if ioConfig.Stdout != os.Stdout {
+		t.Errorf("Expected Stdout to be os.Stdout, got %v", ioConfig.Stdout)
+	}
+	if ioConfig.Stderr != os.Stderr {
+		t.Errorf("Expected Stderr to be os.Stderr, got %v", ioConfig.Stderr)
+	}
+}
+
+func TestDescribeConfig(t *testing.T) {
+	ioConfig := NewIOConfig()
+	cfg := &DescribeConfig{
+		IO:      ioConfig,
+		Dir:     "/test",
+		Cluster: 1,
+		Node:    2,
+	}
+	if cfg.IO != ioConfig {
+		t.Errorf("Expected IO to be set")
+	}
+	if cfg.Dir != "/test" {
+		t.Errorf("Expected Dir to be /test, got %s", cfg.Dir)
+	}
+	if cfg.Cluster != 1 {
+		t.Errorf("Expected Cluster to be 1, got %d", cfg.Cluster)
+	}
+	if cfg.Node != 2 {
+		t.Errorf("Expected Node to be 2, got %d", cfg.Node)
+	}
+}
+
+func TestScanConfig(t *testing.T) {
+	ioConfig := NewIOConfig()
+	cfg := &ScanConfig{
+		IO:                ioConfig,
+		Dir:               "/test",
+		Cluster:           1,
+		Node:              2,
+		From:              10,
+		To:                20,
+		Format:            "json",
+		DecodeEntryHeader: true,
+		DecodeEntryCmd:    false,
+	}
+	if cfg.IO != ioConfig {
+		t.Errorf("Expected IO to be set")
+	}
+	if cfg.Dir != "/test" {
+		t.Errorf("Expected Dir to be /test, got %s", cfg.Dir)
+	}
+	if cfg.Format != "json" {
+		t.Errorf("Expected Format to be json, got %s", cfg.Format)
+	}
+	if !cfg.DecodeEntryHeader {
+		t.Errorf("Expected DecodeEntryHeader to be true")
+	}
+	if cfg.DecodeEntryCmd {
+		t.Errorf("Expected DecodeEntryCmd to be false")
+	}
+}
+
+func TestCustomIOConfig(t *testing.T) {
+	stdoutBuf := new(bytes.Buffer)
+	stderrBuf := new(bytes.Buffer)
+
+	ioConfig := &IOConfig{
+		Stdout: stdoutBuf,
+		Stderr: stderrBuf,
+	}
+
+	if ioConfig.Stdout != stdoutBuf {
+		t.Errorf("Expected custom Stdout")
+	}
+	if ioConfig.Stderr != stderrBuf {
+		t.Errorf("Expected custom Stderr")
+	}
+}
+
+func TestDescribeConfigWithCustomIO(t *testing.T) {
+	stdoutBuf := new(bytes.Buffer)
+	stderrBuf := new(bytes.Buffer)
+
+	ioConfig := &IOConfig{
+		Stdout: stdoutBuf,
+		Stderr: stderrBuf,
+	}
+
+	cfg := &DescribeConfig{
+		IO:  ioConfig,
+		Dir: "/test",
+	}
+
+	if cfg.IO.Stdout != stdoutBuf {
+		t.Errorf("Expected custom Stdout in config")
+	}
+	if cfg.IO.Stderr != stderrBuf {
+		t.Errorf("Expected custom Stderr in config")
+	}
+}
+
+func TestScanConfigWithCustomIO(t *testing.T) {
+	stdoutBuf := new(bytes.Buffer)
+	stderrBuf := new(bytes.Buffer)
+
+	ioConfig := &IOConfig{
+		Stdout: stdoutBuf,
+		Stderr: stderrBuf,
+	}
+
+	cfg := &ScanConfig{
+		IO:  ioConfig,
+		Dir: "/test",
+	}
+
+	if cfg.IO.Stdout != stdoutBuf {
+		t.Errorf("Expected custom Stdout in config")
+	}
+	if cfg.IO.Stderr != stderrBuf {
+		t.Errorf("Expected custom Stderr in config")
+	}
+}
+
+func TestParseDescribeFlagsInvalidDir(t *testing.T) {
+	ioConfig := NewIOConfig()
+	_, err := ParseDescribeFlags(ioConfig, "/nonexistent", []string{})
+	if err == nil {
+		t.Errorf("Expected error for invalid directory")
+	}
+}
+
+func TestParseScanFlagsInvalidDir(t *testing.T) {
+	ioConfig := NewIOConfig()
+	_, err := ParseScanFlags(ioConfig, "/nonexistent", []string{})
+	if err == nil {
+		t.Errorf("Expected error for invalid directory")
+	}
+}
+
+func TestParseSetsIOConfig(t *testing.T) {
+	stdoutBuf := new(bytes.Buffer)
+	stderrBuf := new(bytes.Buffer)
+
+	ioConfig := &IOConfig{
+		Stdout: stdoutBuf,
+		Stderr: stderrBuf,
+	}
+
+	tmpDir, err := os.MkdirTemp("", "logdump-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	descCfg, err := ParseDescribeFlags(ioConfig, tmpDir, []string{})
+	if err != nil {
+		t.Fatalf("Failed to parse describe flags: %v", err)
+	}
+
+	if descCfg.IO != ioConfig {
+		t.Errorf("Expected DescribeConfig.IO to be set to provided ioConfig")
+	}
+
+	scanCfg, err := ParseScanFlags(ioConfig, tmpDir, []string{"--cluster", "1", "--node", "1"})
+	if err != nil {
+		t.Fatalf("Failed to parse scan flags: %v", err)
+	}
+
+	if scanCfg.IO != ioConfig {
+		t.Errorf("Expected ScanConfig.IO to be set to provided ioConfig")
+	}
+}

--- a/tools/logdump/docs/design-entry-cmd-encoding.md
+++ b/tools/logdump/docs/design-entry-cmd-encoding.md
@@ -1,0 +1,254 @@
+# Design: Entry.Cmd Encoding in Dragonboat LogDB
+
+## Context
+
+Dragonboat stores RAFT log entries in LogDB (Pebble/RocksDB). The `Entry.Cmd`
+field holds the actual payload proposed by clients and must be efficiently
+encoded for persistence and decoded for retrieval. This document describes the
+exact encoding mechanism to enable tooling (e.g., `logdump`) to correctly
+interpret entry payloads.
+
+## Key Data Structures
+
+### Entry Structure
+
+The `pb.Entry` protobuf struct (defined in `raftpb/raft.proto`) contains:
+
+```
+message Entry {
+    optional uint64 Term        = 1;
+    optional uint64 Index       = 2;
+    optional EntryType Type     = 3;
+    optional uint64 Key         = 4;
+    optional uint64 ClientID    = 5;
+    optional uint64 SeriesID    = 6;
+    optional uint64 RespondedTo = 7;
+    optional bytes  Cmd         = 8;  // ← Payload field
+}
+```
+
+**Entry types** (`EntryType` enum):
+- `ApplicationEntry` (0): User proposal data or session-managed operations
+- `ConfigChangeEntry` (1): RAFT membership changes
+- `EncodedEntry` (2): Pre-encoded/compressed entry payloads
+- `MetadataEntry` (3): Internal RAFT metadata
+
+### Cmd Payload Types
+
+`Entry.Cmd` is a raw `[]byte` field interpreted based on `Entry.Type`:
+
+| Entry.Type | Cmd Content | Decoding |
+|------------|-------------|----------|
+| `ApplicationEntry` | User proposal data | Raw bytes (application-defined) |
+| `ConfigChangeEntry` | `pb.ConfigChange` protobuf | `ConfigChange.Unmarshal(Cmd)` |
+| `EncodedEntry` | Version + compression + payload | 1-byte header + compressed bytes |
+| `MetadataEntry` | Metadata payload | Raw bytes |
+
+## Encoding Mechanism
+
+### Write Path: Persisting Entry.Cmd
+
+**Location**: `internal/logdb/plain.go` and `internal/logdb/batch.go`
+
+Two encoding modes exist:
+
+#### 1. Plain Encoding (Single Entry)
+
+**Method**: `ent.MarshalTo(buf []byte)` in `plain.go` (Colfer binary codec, generated in `raftpb/raft_optimized.go`)
+
+Process:
+1. Allocate buffer with `SizeUpperLimit()` to determine needed capacity
+2. Call `MarshalTo()` which performs Colfer binary serialization
+3. Write `Entry` struct fields including `Cmd` as sequential index byte + varint length + raw bytes
+4. Store at LogDB key: 28-byte key header + `clusterID` + `nodeID` + `index`
+
+**Key structure** (`internal/logdb/key.go`):
+
+```
+[header: 2B][padding: 2B][clusterID: 8B][nodeID: 8B][index: 8B]
+```
+Header bytes `[0x1, 0x1]` mark entry keys. Total: 28 bytes (`entryKeySize` constant).
+
+#### 2. Batched Encoding (Multiple Entries)
+
+**Method**: `EntryBatch.MarshalTo(buf []byte)` in `raftpb/raft.pb.go` (protobuf wrapper), called from `batch.go`
+
+Process:
+1. Group consecutive entries for compaction
+2. Remove redundant `Term` and `Index` values (store first entry's values once)
+3. `EntryBatch.MarshalTo()` serializes the `repeated Entry` array using **protobuf framing**:
+   - Each entry is wrapped in a protobuf length-delimited field: tag `0x0a` (field 1, wire type 2) + varint length
+   - Inside each frame, `Entry.MarshalTo()` encodes the entry using **Colfer** (colfer index bytes + varints + terminator `0x7f`)
+   (the first entry carries Term/Index; subsequent entries have these zeroed
+   by `compactBatchFields` before marshal, then reconstructed by
+   `restoreBatchFields` on Unmarshal)
+4. Store at LogDB key with batch flag set
+
+**Optimization**: Batch encoding compacted entry array by:
+- Sharing single `Term` and `Index` for consecutive entries with same values
+- Storing `Cmd` bytes in varint length + payload format (uncompressed)
+
+### Cmd Field Encoding Details
+
+**Colfer encoding** for `Entry.Cmd` field (colfer index 7, the 8th field in sequence):
+
+1. Index byte: `0x07`
+2. Varint length of `Cmd` bytes
+3. Raw Cmd bytes (as-is, no further transformation)
+4. End-of-struct terminator: `0x7f` (marks end of the Entry record)
+
+Example: `Cmd = []byte{0x01, 0x02, 0x03}` within an Entry:
+```
+[...][0x07][0x03][0x01][0x02][0x03][0x7f]
+       idx   len   payload             term
+```
+
+Note: Colfer encodes fields sequentially (0–7), not by protobuf field number.
+The Cmd field is index 7, NOT protobuf wire tag `0x42`. The generated code
+lives in `raftpb/raft_optimized.go`; `raftpb/raft.proto` defines the protobuf
+schema used for gRPC/API boundaries, but LogDB persistence uses the Colfer
+codec.
+
+**Special payload encodings**:
+
+#### ConfigChangeEncoding
+
+When `Entry.Type == ConfigChangeEntry`:
+- `Cmd` contains `pb.ConfigChange` marshaled bytes
+- `ConfigChange` structure:
+  ```
+  message ConfigChange {
+    uint64            config_change_id = 1;
+    ConfigChangeType  Type             = 2;
+    uint64            NodeID           = 3;
+    string            Address          = 4;
+    bool              Initialize       = 5;
+  }
+  ```
+- `ConfigChangeType` values: `AddNode`, `RemoveNode`, `AddObserver`, `AddWitness`
+
+#### EncodedEntry Encoding (Version 0)
+
+When `Entry.Type == EncodedEntry`:
+- `Cmd` format: `[header: 1B][payload: N bytes]`
+  - **No compression**: `payload` is raw data
+  - **Snappy compression**: `payload` is a snappy stream (starts with
+    uvarint-encoded uncompressed size, followed by snappy-compressed data)
+- Header bits:
+  ```
+  [Version: 4 bits][Compression: 3 bits][Session: 1 bit]
+    Bits 7-4           Bits 3-1            Bit 0
+  ```
+- Version 0 (bits 7-4 = 0) is current
+- Compression: 0=none (`EENoCompression = 0 << 1`), 1=snappy (`EESnappy = 1 << 1`)
+- Session bit: reserved for future session info (always 0 in Version 0)
+
+**Note**: The header constants are:
+- `EEHeaderSize = 1`: header byte size
+- `EEV0 = 0 << 4`: version 0
+- `EENoCompression = 0 << 1`: no compression flag
+- `EESnappy = 1 << 1`: snappy compression flag
+- `EENoSession = 0`: no session flag
+- `EEHasSession = 1`: has session flag
+
+## Decoding Mechanism
+
+### Read Path: Loading Entry.Cmd
+
+**Location**: `internal/logdb/db.go` → `iterateEntries()` → `r.entries.iterate()`
+
+Two decoding modes:
+
+#### 1. Plain Decoding
+
+**Method**: `Entry.Unmarshal(data []byte)` in `raftpb/raft_optimized.go` (Colfer codec)
+
+Process:
+1. Read LogDB value bytes at entry key
+2. Call `Entry.Unmarshal()` which:
+   - Reads colfer index bytes to identify fields
+   - For index 7 (Cmd): read varint length, then bytes
+   - Populates `Entry.Cmd` with raw byte slice
+3. Return decoded `Entry` struct
+
+#### 2. Batched Decoding
+
+**Method**: `EntryBatch.Unmarshal(data []byte)` in `raftpb/raft.pb.go` → `restoreBatchFields()` in `batch.go`
+
+Process:
+1. Read LogDB value bytes at batch key
+2. `EntryBatch.Unmarshal()` parses the protobuf framing:
+   - Reads field tags and varint lengths to extract each entry frame
+   - For each frame, calls `Entry.Unmarshal()` (colfer) to decode the entry
+3. `restoreBatchFields()` post-processes the decoded entries:
+   - If entries[1:] have zeroed Term/Index, fills them from entries[0] values
+   - `Cmd` field: already decoded during step 2's colfer unmarshal
+4. Return array of decoded `Entry` structs
+
+### Cmd Field Decoding Details
+
+**Colfer decoding** for the Cmd field:
+1. Read index byte `0x07`, identifying the Cmd field
+2. Read varint length `L`
+3. Read next `L` bytes into `Entry.Cmd`
+
+**Special payload decoding**:
+
+- **ConfigChange**: When `Entry.Type == ConfigChangeEntry`, call `ConfigChange.Unmarshal(Entry.Cmd)` to parse membership change details
+
+- **EncodedEntry**: When `Entry.Type == EncodedEntry`:
+  1. Parse header byte: extract version (bits 7-4), compression (bits 3-1), session (bit 0)
+  2. If compression == none: `payload = Cmd[1:]` (skip header)
+  3. If compression == snappy:
+     a. `Cmd[1:]` is a snappy stream (starts with a uvarint-encoded uncompressed size)
+     b. Read uncompressed size via `binary.Uvarint(Cmd[1:])` to size the output buffer
+     c. Call `dio.DecompressSnappyBlock(Cmd[1:], dst)` — returns `error`;
+        `dst` must be pre-allocated to exactly the uncompressed size
+
+- **ApplicationEntry**: Treat `Entry.Cmd` as opaque user bytes (no standard interpretation)
+
+
+## Session Management Encoding
+
+**Critical**: Session-related operations are **NOT** encoded in `Entry.Cmd` payload. They are identified via `Entry.SeriesID` values:
+
+| SeriesID Value | Operation | Entry.Type | Cmd Content |
+|---------------|-----------|------------|-------------|
+| `math.MaxUint64 - 1` | New session request | `ApplicationEntry` | `nil` |
+| `math.MaxUint64` | End session request | `ApplicationEntry` | `nil` |
+| `0` | NoOP session operation | `ApplicationEntry` | `nil` |
+| `Other` | Session-managed user proposal | `ApplicationEntry` | User data |
+
+**Helper methods** in `raftpb/raft.go`:
+- `IsNewSessionRequest()`: checks `SeriesID == client.SeriesIDForRegister`
+- `IsEndOfSessionRequest()`: checks `SeriesID == client.SeriesIDForUnregister`
+- `IsNoOPSession()`: checks `SeriesID == client.NoOPSeriesID`
+
+**Non-session entries**: `Entry.ClientID == NotSessionManagedClientID` (0).
+These bypass all session logic regardless of `SeriesID` value.
+
+## Implementation File Reference
+
+| File | Purpose |
+|------|---------|
+| `raftpb/raft.proto` | Entry protobuf definition with Cmd field |
+| `internal/logdb/plain.go` | Plain encode/decode for single entries |
+| `internal/logdb/batch.go` | Batched encode/decode with compaction |
+| `internal/logdb/key.go` | LogDB key structure constants |
+| `internal/logdb/db.go` | `saveEntries()` and `iterateEntries()` orchestration |
+| `raftpb/raft.go` | Session management helpers (SeriesID checks) |
+| `internal/rsm/encoded.go` | **EncodedEntry compression/decompression implementation** |
+| `raftpb/raft_optimized.go` | Colfer binary codec for Entry |
+
+## Assumptions & Contingencies
+
+- **Wire format**: LogDB persistence uses the Colfer binary codec
+  (`raftpb/raft_optimized.go`), not protobuf. The protobuf schema in
+  `raft.proto` defines the data model and is used for gRPC transport, but
+  `Entry.MarshalTo()` / `Entry.Unmarshal()` in the LogDB path dispatch to the
+  Colfer-generated code.
+- **Encoding stability**: Colfer field indices and header format are stable
+  across dragonboat v3.x versions; breaks may occur with major version bumps.
+- **Contingency**: If entry decoding fails, verify the colfer field ordering in
+  `raft_optimized.go:marshalTo()` against the expected indices — field
+  reordering would break the format.

--- a/tools/logdump/dumper.go
+++ b/tools/logdump/dumper.go
@@ -1,0 +1,192 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/cockroachdb/errors"
+	"github.com/lni/dragonboat/v3/raftio"
+	pb "github.com/lni/dragonboat/v3/raftpb"
+)
+
+// NodeSummary summarizes a single Raft node's data found in the LogDB.
+type NodeSummary struct {
+	ClusterID, NodeID                 uint64
+	Term, Vote, Commit                uint64
+	FirstIndex, LastIndex, EntryCount uint64
+	SnapshotCnt                       int
+	Bootstrap                         string
+}
+
+// ScanResult holds all data returned by Scan.
+type ScanResult struct {
+	State           pb.State
+	Snapshots       []pb.Snapshot
+	Entries         []pb.Entry
+	From, To, Limit uint64
+	FirstIndex      uint64
+	LastIndex       uint64
+	EntryCount      uint64
+}
+
+// Dumper wraps an ILogDB to provide high-level inspection methods.
+type Dumper struct {
+	db raftio.ILogDB
+}
+
+// NewDumper creates a new Dumper wrapping the given ILogDB.
+func NewDumper(db raftio.ILogDB) *Dumper {
+	return &Dumper{db: db}
+}
+
+// Close closes the underlying LogDB.
+func (d *Dumper) Close() error {
+	return d.db.Close()
+}
+
+// Describe returns a summary of all Raft nodes in the LogDB, optionally
+// filtered by cluster and/or node ID. A zero-valued filter is ignored.
+func (d *Dumper) Describe(clusterFilter, nodeFilter uint64) ([]NodeSummary, error) {
+	nodes, err := d.db.ListNodeInfo()
+	if err != nil {
+		return nil, errors.Wrapf(err, "list node info")
+	}
+
+	var result []NodeSummary
+	for _, ni := range nodes {
+		if clusterFilter != 0 && ni.ClusterID != clusterFilter {
+			continue
+		}
+		if nodeFilter != 0 && ni.NodeID != nodeFilter {
+			continue
+		}
+		ns := NodeSummary{
+			ClusterID: ni.ClusterID,
+			NodeID:    ni.NodeID,
+		}
+
+		// Read persisted Raft state (term, vote, commit, entry range).
+		// Find the latest snapshot to use as the snapshotIndex parameter.
+		snaps, err := d.db.ListSnapshots(ni.ClusterID, ni.NodeID, math.MaxUint64)
+		if err != nil {
+			return nil, errors.Wrapf(err, "list snapshots for cluster=%d node=%d", ni.ClusterID, ni.NodeID)
+		}
+		ns.SnapshotCnt = len(snaps)
+
+		snapshotIndex := uint64(0)
+		if len(snaps) > 0 {
+			// Use the latest snapshot's index as snapshotIndex
+			snapshotIndex = snaps[len(snaps)-1].Index
+		}
+
+		// Read persisted Raft state (term, vote, commit, entry range).
+		rs, err := d.db.ReadRaftState(ni.ClusterID, ni.NodeID, snapshotIndex)
+		if err == nil {
+			ns.Term = rs.State.Term
+			ns.Vote = rs.State.Vote
+			ns.Commit = rs.State.Commit
+			ns.FirstIndex = rs.FirstIndex
+			ns.EntryCount = rs.EntryCount
+			if rs.EntryCount > 0 {
+				ns.LastIndex = rs.FirstIndex + rs.EntryCount - 1
+			}
+		} else if err != raftio.ErrNoSavedLog {
+			return nil, errors.Wrapf(err, "read raft state for cluster=%d node=%d snapshotIndex=%d", ni.ClusterID, ni.NodeID, snapshotIndex)
+		}
+
+		// Read bootstrap info.
+		bootstrap, err := d.db.GetBootstrapInfo(ni.ClusterID, ni.NodeID)
+		if err == nil {
+			ns.Bootstrap = fmt.Sprintf("join=%v, %d addrs, sm=%s",
+				bootstrap.Join, len(bootstrap.Addresses), bootstrap.Type.String())
+		} else if err == raftio.ErrNoBootstrapInfo {
+			ns.Bootstrap = "(none)"
+		} else {
+			return nil, errors.Wrapf(err, "get bootstrap info for cluster=%d node=%d", ni.ClusterID, ni.NodeID)
+		}
+
+		result = append(result, ns)
+	}
+	return result, nil
+}
+
+// GetEntries retrieves the Raft state, snapshots, and log entries for the
+// specified node. The entry range is clamped to the available log and an
+// optional limit is applied to the returned entries.
+func (d *Dumper) Scan(clusterID, nodeID, from, to, limit uint64) (*ScanResult, error) {
+	// Find the latest snapshot with index < from to use as snapshotIndex.
+	snapshotIndex := uint64(0)
+	snaps, err := d.db.ListSnapshots(clusterID, nodeID, math.MaxUint64)
+	if err != nil {
+		return nil, errors.Wrapf(err, "list snapshots for cluster=%d node=%d", clusterID, nodeID)
+	}
+	for i := len(snaps) - 1; i >= 0; i-- {
+		if snaps[i].Index < from {
+			snapshotIndex = snaps[i].Index
+			break
+		}
+	}
+
+	// Read persisted Raft state to discover the available entry range.
+	rs, err := d.db.ReadRaftState(clusterID, nodeID, snapshotIndex)
+	if err != nil {
+		return nil, errors.Wrapf(err, "read raft state for cluster=%d node=%d snapshotIndex=%d", clusterID, nodeID, snapshotIndex)
+	}
+
+	res := &ScanResult{
+		From:       from,
+		To:         to,
+		Limit:      limit,
+		State:      rs.State,
+		FirstIndex: rs.FirstIndex,
+		EntryCount: rs.EntryCount,
+	}
+	if rs.EntryCount > 0 {
+		res.LastIndex = rs.FirstIndex + rs.EntryCount - 1
+	}
+
+	// Clamp from/to to the available range.
+	if from == 0 || from < rs.FirstIndex {
+		from = rs.FirstIndex
+	}
+	if to == 0 {
+		to = from + rs.EntryCount
+	}
+	if to > rs.FirstIndex+rs.EntryCount {
+		to = rs.FirstIndex + rs.EntryCount
+	}
+	if limit != 0 && to > from+limit {
+		to = from + limit
+	}
+	res.From = from
+	res.To = to
+
+	// List snapshots within the requested range.
+	res.Snapshots, err = d.db.ListSnapshots(clusterID, nodeID, to)
+	if err != nil {
+		return nil, errors.Wrapf(err, "list snapshots for cluster=%d node=%d", clusterID, nodeID)
+	}
+
+	// Iterate entries in [from, to).
+	if from < to {
+		entries, _, err := d.db.IterateEntries(nil, 0, clusterID, nodeID, from, to, math.MaxUint64)
+		if err != nil {
+			return nil, errors.Wrapf(err, "iterate entries for cluster=%d node=%d from=%d to=%d", clusterID, nodeID, from, to)
+		}
+		res.Entries = entries
+	}
+
+	return res, nil
+}

--- a/tools/logdump/logdump.go
+++ b/tools/logdump/logdump.go
@@ -77,3 +77,7 @@ func (l *LogDump) GetRaftDataStatus() (raftpb.RaftDataStatus, error) {
 
 	return s, nil
 }
+
+func (l *LogDump) Dumper() Dumper {
+	return *NewDumper(l.log)
+}

--- a/tools/logdump/logdump.go
+++ b/tools/logdump/logdump.go
@@ -13,7 +13,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"path"
 
@@ -49,8 +48,7 @@ func OpenLogDumpReadOnly(dir string, ignoreLock bool) (*LogDump, error) {
 	db, err := logdb.OpenReadOnlyLogDB(config.GetDefaultLogDBConfig(),
 		dir, path.Join(dir, "wal"), vfs, f)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error opening database: %v\n", err)
-		os.Exit(1)
+		return nil, errors.Wrap(err, "error opening database")
 	}
 
 	return &LogDump{

--- a/tools/logdump/logdump.go
+++ b/tools/logdump/logdump.go
@@ -1,0 +1,192 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/cockroachdb/errors"
+	"github.com/lni/dragonboat/v3/raftio"
+	pb "github.com/lni/dragonboat/v3/raftpb"
+)
+
+// NodeSummary summarizes a single Raft node's data found in the LogDB.
+type NodeSummary struct {
+	ClusterID, NodeID                 uint64
+	Term, Vote, Commit                uint64
+	FirstIndex, LastIndex, EntryCount uint64
+	SnapshotCnt                       int
+	Bootstrap                         string
+}
+
+// ScanResult holds all data returned by Scan.
+type ScanResult struct {
+	State           pb.State
+	Snapshots       []pb.Snapshot
+	Entries         []pb.Entry
+	From, To, Limit uint64
+	FirstIndex      uint64
+	LastIndex       uint64
+	EntryCount      uint64
+}
+
+// Dumper wraps an ILogDB to provide high-level inspection methods.
+type Dumper struct {
+	db raftio.ILogDB
+}
+
+// NewDumper creates a new Dumper wrapping the given ILogDB.
+func NewDumper(db raftio.ILogDB) *Dumper {
+	return &Dumper{db: db}
+}
+
+// Close closes the underlying LogDB.
+func (d *Dumper) Close() error {
+	return d.db.Close()
+}
+
+// Describe returns a summary of all Raft nodes in the LogDB, optionally
+// filtered by cluster and/or node ID. A zero-valued filter is ignored.
+func (d *Dumper) Describe(clusterFilter, nodeFilter uint64) ([]NodeSummary, error) {
+	nodes, err := d.db.ListNodeInfo()
+	if err != nil {
+		return nil, errors.Wrapf(err, "list node info")
+	}
+
+	var result []NodeSummary
+	for _, ni := range nodes {
+		if clusterFilter != 0 && ni.ClusterID != clusterFilter {
+			continue
+		}
+		if nodeFilter != 0 && ni.NodeID != nodeFilter {
+			continue
+		}
+		ns := NodeSummary{
+			ClusterID: ni.ClusterID,
+			NodeID:    ni.NodeID,
+		}
+
+		// Read persisted Raft state (term, vote, commit, entry range).
+		// Find the latest snapshot to use as the snapshotIndex parameter.
+		snaps, err := d.db.ListSnapshots(ni.ClusterID, ni.NodeID, math.MaxUint64)
+		if err != nil {
+			return nil, errors.Wrapf(err, "list snapshots for cluster=%d node=%d", ni.ClusterID, ni.NodeID)
+		}
+		ns.SnapshotCnt = len(snaps)
+
+		snapshotIndex := uint64(0)
+		if len(snaps) > 0 {
+			// Use the latest snapshot's index as snapshotIndex
+			snapshotIndex = snaps[len(snaps)-1].Index
+		}
+
+		// Read persisted Raft state (term, vote, commit, entry range).
+		rs, err := d.db.ReadRaftState(ni.ClusterID, ni.NodeID, snapshotIndex)
+		if err == nil {
+			ns.Term = rs.State.Term
+			ns.Vote = rs.State.Vote
+			ns.Commit = rs.State.Commit
+			ns.FirstIndex = rs.FirstIndex
+			ns.EntryCount = rs.EntryCount
+			if rs.EntryCount > 0 {
+				ns.LastIndex = rs.FirstIndex + rs.EntryCount - 1
+			}
+		} else if err != raftio.ErrNoSavedLog {
+			return nil, errors.Wrapf(err, "read raft state for cluster=%d node=%d snapshotIndex=%d", ni.ClusterID, ni.NodeID, snapshotIndex)
+		}
+
+		// Read bootstrap info.
+		bootstrap, err := d.db.GetBootstrapInfo(ni.ClusterID, ni.NodeID)
+		if err == nil {
+			ns.Bootstrap = fmt.Sprintf("join=%v, %d addrs, sm=%s",
+				bootstrap.Join, len(bootstrap.Addresses), bootstrap.Type.String())
+		} else if err == raftio.ErrNoBootstrapInfo {
+			ns.Bootstrap = "(none)"
+		} else {
+			return nil, errors.Wrapf(err, "get bootstrap info for cluster=%d node=%d", ni.ClusterID, ni.NodeID)
+		}
+
+		result = append(result, ns)
+	}
+	return result, nil
+}
+
+// GetEntries retrieves the Raft state, snapshots, and log entries for the
+// specified node. The entry range is clamped to the available log and an
+// optional limit is applied to the returned entries.
+func (d *Dumper) Scan(clusterID, nodeID, from, to, limit uint64) (*ScanResult, error) {
+	// Find the latest snapshot with index < from to use as snapshotIndex.
+	snapshotIndex := uint64(0)
+	snaps, err := d.db.ListSnapshots(clusterID, nodeID, math.MaxUint64)
+	if err != nil {
+		return nil, errors.Wrapf(err, "list snapshots for cluster=%d node=%d", clusterID, nodeID)
+	}
+	for i := len(snaps) - 1; i >= 0; i-- {
+		if snaps[i].Index < from {
+			snapshotIndex = snaps[i].Index
+			break
+		}
+	}
+
+	// Read persisted Raft state to discover the available entry range.
+	rs, err := d.db.ReadRaftState(clusterID, nodeID, snapshotIndex)
+	if err != nil {
+		return nil, errors.Wrapf(err, "read raft state for cluster=%d node=%d snapshotIndex=%d", clusterID, nodeID, snapshotIndex)
+	}
+
+	res := &ScanResult{
+		From:       from,
+		To:         to,
+		Limit:      limit,
+		State:      rs.State,
+		FirstIndex: rs.FirstIndex,
+		EntryCount: rs.EntryCount,
+	}
+	if rs.EntryCount > 0 {
+		res.LastIndex = rs.FirstIndex + rs.EntryCount - 1
+	}
+
+	// Clamp from/to to the available range.
+	if from == 0 || from < rs.FirstIndex {
+		from = rs.FirstIndex
+	}
+	if to == 0 {
+		to = from + rs.EntryCount
+	}
+	if to > rs.FirstIndex+rs.EntryCount {
+		to = rs.FirstIndex + rs.EntryCount
+	}
+	if limit != 0 && to > from+limit {
+		to = from + limit
+	}
+	res.From = from
+	res.To = to
+
+	// List snapshots within the requested range.
+	res.Snapshots, err = d.db.ListSnapshots(clusterID, nodeID, to)
+	if err != nil {
+		return nil, errors.Wrapf(err, "list snapshots for cluster=%d node=%d", clusterID, nodeID)
+	}
+
+	// Iterate entries in [from, to).
+	if from < to {
+		entries, _, err := d.db.IterateEntries(nil, 0, clusterID, nodeID, from, to, math.MaxUint64)
+		if err != nil {
+			return nil, errors.Wrapf(err, "iterate entries for cluster=%d node=%d from=%d to=%d", clusterID, nodeID, from, to)
+		}
+		res.Entries = entries
+	}
+
+	return res, nil
+}

--- a/tools/logdump/logdump.go
+++ b/tools/logdump/logdump.go
@@ -14,179 +14,66 @@ package main
 
 import (
 	"fmt"
-	"math"
+	"os"
+	"path"
 
 	"github.com/cockroachdb/errors"
+	"github.com/lni/dragonboat/v3/config"
+	"github.com/lni/dragonboat/v3/internal/fileutil"
+	"github.com/lni/dragonboat/v3/internal/logdb"
+	"github.com/lni/dragonboat/v3/internal/logdb/kv/pebble"
+	"github.com/lni/dragonboat/v3/internal/vfs"
 	"github.com/lni/dragonboat/v3/raftio"
-	pb "github.com/lni/dragonboat/v3/raftpb"
+	"github.com/lni/dragonboat/v3/raftpb"
 )
 
-// NodeSummary summarizes a single Raft node's data found in the LogDB.
-type NodeSummary struct {
-	ClusterID, NodeID                 uint64
-	Term, Vote, Commit                uint64
-	FirstIndex, LastIndex, EntryCount uint64
-	SnapshotCnt                       int
-	Bootstrap                         string
+const flagFilename = "dragonboat.ds"
+
+type LogDump struct {
+	dir string
+	vfs vfs.IFS
+	log raftio.ILogDB
 }
 
-// ScanResult holds all data returned by Scan.
-type ScanResult struct {
-	State           pb.State
-	Snapshots       []pb.Snapshot
-	Entries         []pb.Entry
-	From, To, Limit uint64
-	FirstIndex      uint64
-	LastIndex       uint64
-	EntryCount      uint64
-}
+func OpenLogDumpReadOnly(dir string, ignoreLock bool) (*LogDump, error) {
+	if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
+		return nil, errors.Wrapf(err, "error: invalid data directory %q", dir)
+	}
 
-// Dumper wraps an ILogDB to provide high-level inspection methods.
-type Dumper struct {
-	db raftio.ILogDB
-}
+	var f = pebble.PebbleReadOnlyKVStore
+	if ignoreLock {
+		f = pebble.PebbleReadOnlyNoLockKVStore
+	}
+	var vfs = vfs.DefaultFS
 
-// NewDumper creates a new Dumper wrapping the given ILogDB.
-func NewDumper(db raftio.ILogDB) *Dumper {
-	return &Dumper{db: db}
-}
-
-// Close closes the underlying LogDB.
-func (d *Dumper) Close() error {
-	return d.db.Close()
-}
-
-// Describe returns a summary of all Raft nodes in the LogDB, optionally
-// filtered by cluster and/or node ID. A zero-valued filter is ignored.
-func (d *Dumper) Describe(clusterFilter, nodeFilter uint64) ([]NodeSummary, error) {
-	nodes, err := d.db.ListNodeInfo()
+	db, err := logdb.OpenReadOnlyLogDB(config.GetDefaultLogDBConfig(),
+		dir, path.Join(dir, "wal"), vfs, f)
 	if err != nil {
-		return nil, errors.Wrapf(err, "list node info")
+		fmt.Fprintf(os.Stderr, "error opening database: %v\n", err)
+		os.Exit(1)
 	}
 
-	var result []NodeSummary
-	for _, ni := range nodes {
-		if clusterFilter != 0 && ni.ClusterID != clusterFilter {
-			continue
-		}
-		if nodeFilter != 0 && ni.NodeID != nodeFilter {
-			continue
-		}
-		ns := NodeSummary{
-			ClusterID: ni.ClusterID,
-			NodeID:    ni.NodeID,
-		}
-
-		// Read persisted Raft state (term, vote, commit, entry range).
-		// Find the latest snapshot to use as the snapshotIndex parameter.
-		snaps, err := d.db.ListSnapshots(ni.ClusterID, ni.NodeID, math.MaxUint64)
-		if err != nil {
-			return nil, errors.Wrapf(err, "list snapshots for cluster=%d node=%d", ni.ClusterID, ni.NodeID)
-		}
-		ns.SnapshotCnt = len(snaps)
-
-		snapshotIndex := uint64(0)
-		if len(snaps) > 0 {
-			// Use the latest snapshot's index as snapshotIndex
-			snapshotIndex = snaps[len(snaps)-1].Index
-		}
-
-		// Read persisted Raft state (term, vote, commit, entry range).
-		rs, err := d.db.ReadRaftState(ni.ClusterID, ni.NodeID, snapshotIndex)
-		if err == nil {
-			ns.Term = rs.State.Term
-			ns.Vote = rs.State.Vote
-			ns.Commit = rs.State.Commit
-			ns.FirstIndex = rs.FirstIndex
-			ns.EntryCount = rs.EntryCount
-			if rs.EntryCount > 0 {
-				ns.LastIndex = rs.FirstIndex + rs.EntryCount - 1
-			}
-		} else if err != raftio.ErrNoSavedLog {
-			return nil, errors.Wrapf(err, "read raft state for cluster=%d node=%d snapshotIndex=%d", ni.ClusterID, ni.NodeID, snapshotIndex)
-		}
-
-		// Read bootstrap info.
-		bootstrap, err := d.db.GetBootstrapInfo(ni.ClusterID, ni.NodeID)
-		if err == nil {
-			ns.Bootstrap = fmt.Sprintf("join=%v, %d addrs, sm=%s",
-				bootstrap.Join, len(bootstrap.Addresses), bootstrap.Type.String())
-		} else if err == raftio.ErrNoBootstrapInfo {
-			ns.Bootstrap = "(none)"
-		} else {
-			return nil, errors.Wrapf(err, "get bootstrap info for cluster=%d node=%d", ni.ClusterID, ni.NodeID)
-		}
-
-		result = append(result, ns)
-	}
-	return result, nil
+	return &LogDump{
+		dir: dir,
+		vfs: vfs,
+		log: db,
+	}, nil
 }
 
-// GetEntries retrieves the Raft state, snapshots, and log entries for the
-// specified node. The entry range is clamped to the available log and an
-// optional limit is applied to the returned entries.
-func (d *Dumper) Scan(clusterID, nodeID, from, to, limit uint64) (*ScanResult, error) {
-	// Find the latest snapshot with index < from to use as snapshotIndex.
-	snapshotIndex := uint64(0)
-	snaps, err := d.db.ListSnapshots(clusterID, nodeID, math.MaxUint64)
-	if err != nil {
-		return nil, errors.Wrapf(err, "list snapshots for cluster=%d node=%d", clusterID, nodeID)
-	}
-	for i := len(snaps) - 1; i >= 0; i-- {
-		if snaps[i].Index < from {
-			snapshotIndex = snaps[i].Index
-			break
-		}
+func (l *LogDump) VFS() vfs.IFS {
+	return l.vfs
+}
+
+func (l *LogDump) LogDB() raftio.ILogDB {
+	return l.log
+}
+
+func (l *LogDump) GetRaftDataStatus() (raftpb.RaftDataStatus, error) {
+	s := raftpb.RaftDataStatus{}
+
+	if err := fileutil.GetFlagFileContent(l.dir, flagFilename, &s, l.vfs); err != nil {
+		return s, errors.Wrapf(err, "reading flag file content from %s\n", path.Join(l.dir, flagFilename))
 	}
 
-	// Read persisted Raft state to discover the available entry range.
-	rs, err := d.db.ReadRaftState(clusterID, nodeID, snapshotIndex)
-	if err != nil {
-		return nil, errors.Wrapf(err, "read raft state for cluster=%d node=%d snapshotIndex=%d", clusterID, nodeID, snapshotIndex)
-	}
-
-	res := &ScanResult{
-		From:       from,
-		To:         to,
-		Limit:      limit,
-		State:      rs.State,
-		FirstIndex: rs.FirstIndex,
-		EntryCount: rs.EntryCount,
-	}
-	if rs.EntryCount > 0 {
-		res.LastIndex = rs.FirstIndex + rs.EntryCount - 1
-	}
-
-	// Clamp from/to to the available range.
-	if from == 0 || from < rs.FirstIndex {
-		from = rs.FirstIndex
-	}
-	if to == 0 {
-		to = from + rs.EntryCount
-	}
-	if to > rs.FirstIndex+rs.EntryCount {
-		to = rs.FirstIndex + rs.EntryCount
-	}
-	if limit != 0 && to > from+limit {
-		to = from + limit
-	}
-	res.From = from
-	res.To = to
-
-	// List snapshots within the requested range.
-	res.Snapshots, err = d.db.ListSnapshots(clusterID, nodeID, to)
-	if err != nil {
-		return nil, errors.Wrapf(err, "list snapshots for cluster=%d node=%d", clusterID, nodeID)
-	}
-
-	// Iterate entries in [from, to).
-	if from < to {
-		entries, _, err := d.db.IterateEntries(nil, 0, clusterID, nodeID, from, to, math.MaxUint64)
-		if err != nil {
-			return nil, errors.Wrapf(err, "iterate entries for cluster=%d node=%d from=%d to=%d", clusterID, nodeID, from, to)
-		}
-		res.Entries = entries
-	}
-
-	return res, nil
+	return s, nil
 }

--- a/tools/logdump/main.go
+++ b/tools/logdump/main.go
@@ -15,16 +15,32 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"path"
 
+	"github.com/cockroachdb/errors"
 	"github.com/lni/dragonboat/v3/tools/logdump/proto"
 )
+
+type IOConfig struct {
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+func NewIOConfig() *IOConfig {
+	return &IOConfig{
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+}
 
 type DescribeConfig struct {
 	Dir     string
 	Cluster uint64
 	Node    uint64
+
+	IO *IOConfig
 }
 
 type ScanConfig struct {
@@ -42,6 +58,7 @@ type ScanConfig struct {
 	DecodeEntryHeader bool
 	DecodeEntryCmd    bool
 
+	IO         *IOConfig
 	CmdDecoder proto.CmdDecoderFunc
 }
 
@@ -63,67 +80,75 @@ func main() {
 		}
 	}
 
+	var err error
 	switch cmd {
 	case "describe":
-		if len(os.Args) < 3 {
-			fmt.Fprintf(os.Stderr, "error: data directory is required\n\n")
-			PrintUsage()
-			os.Exit(1)
-		}
-		cfg, err := ParseDescribeFlags(os.Args[2], os.Args[3:])
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error: %v\n\n", err)
-			PrintUsage()
-			os.Exit(1)
-		}
-		DescribeCmd(cfg)
+		err = runDescribe(os.Args[2:])
 	case "scan":
-		if len(os.Args) < 3 {
-			fmt.Fprintf(os.Stderr, "error: data directory is required\n\n")
-			PrintUsage()
-			os.Exit(1)
-		}
-		cfg, err := ParseScanFlags(os.Args[2], os.Args[3:])
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error: %v\n\n", err)
-			PrintUsage()
-			os.Exit(1)
-		}
-		ScanCmd(cfg)
+		err = runScan(os.Args[2:])
 	case "-h", "--help", "help":
 		PrintUsage()
 	default:
-		fmt.Fprintf(os.Stderr, "unknown command: %s\n\n", cmd)
+		err = errors.Newf("unknown command: %s", cmd)
 		PrintUsage()
+	}
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
+}
+
+func runDescribe(args []string) error {
+	if len(args) == 0 {
+		return errors.New("error: data directory is required")
+	}
+
+	ioConfig := NewIOConfig()
+	cfg, err := ParseDescribeFlags(ioConfig, args[0], args[1:])
+	if err != nil {
+		return err
+	}
+
+	return DescribeCmd(cfg)
+}
+
+func runScan(args []string) error {
+	if len(args) == 0 {
+		return errors.New("error: data directory is required")
+	}
+
+	ioConfig := NewIOConfig()
+	cfg, err := ParseScanFlags(ioConfig, args[0], args[1:])
+	if err != nil {
+		return err
+	}
+
+	return ScanCmd(cfg)
 }
 
 func DescribeCmd(cfg *DescribeConfig) error {
 	ld, err := OpenLogDumpReadOnly(cfg.Dir, true)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error opening database:\n%v", err)
-		os.Exit(1)
+		return errors.Wrap(err, "error opening database")
 	}
 
 	s, err := ld.GetRaftDataStatus()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error reading %s: %v\n", path.Join(cfg.Dir, flagFilename), err)
-		os.Exit(1)
+		return errors.Wrapf(err, "error reading %s", path.Join(cfg.Dir, flagFilename))
 	}
 
-	fmt.Println("MANIFEST:", ManifestString(&s))
+	fmt.Fprintln(cfg.IO.Stdout, "MANIFEST:", ManifestString(&s))
 
 	d := ld.Dumper()
 	defer d.Close()
 
 	summaries, err := d.Describe(cfg.Cluster, cfg.Node)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error describing nodes: %v\n", err)
-		os.Exit(1)
+		return errors.Wrap(err, "error describing nodes")
 	}
 
-	PrintSummary(summaries)
+	PrintSummary(cfg.IO.Stdout, summaries)
 
 	return nil
 }
@@ -131,8 +156,7 @@ func DescribeCmd(cfg *DescribeConfig) error {
 func ScanCmd(cfg *ScanConfig) error {
 	ld, err := OpenLogDumpReadOnly(cfg.Dir, true)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error opening database:\n%v", err)
-		os.Exit(1)
+		return errors.Wrap(err, "error opening database")
 	}
 
 	d := ld.Dumper()
@@ -140,8 +164,7 @@ func ScanCmd(cfg *ScanConfig) error {
 
 	result, err := d.Scan(cfg.Cluster, cfg.Node, cfg.From, cfg.To, cfg.Limit)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error getting entries: %v\n", err)
-		os.Exit(1)
+		return errors.Wrap(err, "error getting entries")
 	}
 
 	var opts []proto.DecodeOption
@@ -157,17 +180,17 @@ func ScanCmd(cfg *ScanConfig) error {
 
 	switch cfg.Format {
 	case "json":
-		PrintScanJSON(result, cfg.Cluster, cfg.Node, opts...)
+		PrintScanJSON(cfg.IO.Stdout, result, cfg.Cluster, cfg.Node, opts...)
 	default:
-		PrintScanTable(result, cfg.Cluster, cfg.Node, opts...)
+		PrintScanTable(cfg.IO.Stdout, result, cfg.Cluster, cfg.Node, opts...)
 	}
 
 	return nil
 }
 
-func ParseDescribeFlags(dir string, flagArgs []string) (*DescribeConfig, error) {
+func ParseDescribeFlags(io *IOConfig, dir string, flagArgs []string) (*DescribeConfig, error) {
 	if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
-		return nil, fmt.Errorf("invalid data directory %q", dir)
+		return nil, errors.Wrapf(err, "invalid data directory %q", dir)
 	}
 
 	fs := flag.NewFlagSet("describe", flag.ExitOnError)
@@ -178,15 +201,16 @@ func ParseDescribeFlags(dir string, flagArgs []string) (*DescribeConfig, error) 
 	}
 
 	return &DescribeConfig{
+		IO:      io,
 		Dir:     dir,
 		Cluster: *cluster,
 		Node:    *node,
 	}, nil
 }
 
-func ParseScanFlags(dir string, flagArgs []string) (*ScanConfig, error) {
+func ParseScanFlags(io *IOConfig, dir string, flagArgs []string) (*ScanConfig, error) {
 	if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
-		return nil, fmt.Errorf("invalid data directory %q", dir)
+		return nil, errors.Wrapf(err, "invalid data directory %q", dir)
 	}
 
 	fs := flag.NewFlagSet("scan", flag.ExitOnError)
@@ -209,14 +233,14 @@ func ParseScanFlags(dir string, flagArgs []string) (*ScanConfig, error) {
 	}
 
 	if *cluster == 0 {
-		return nil, fmt.Errorf("--cluster is required and must be > 0")
+		return nil, errors.New("--cluster is required and must be > 0")
 	}
 	if *node == 0 {
-		return nil, fmt.Errorf("--node is required and must be > 0")
+		return nil, errors.New("--node is required and must be > 0")
 	}
 
 	if *format != "table" && *format != "json" {
-		return nil, fmt.Errorf("--format must be \"table\" or \"json\", got %q", *format)
+		return nil, errors.Errorf("--format must be \"table\" or \"json\", got %q", *format)
 	}
 
 	// --index is a shortcut for --from N --to N+1.
@@ -226,6 +250,7 @@ func ParseScanFlags(dir string, flagArgs []string) (*ScanConfig, error) {
 	}
 
 	return &ScanConfig{
+		IO:                io,
 		Dir:               dir,
 		Cluster:           *cluster,
 		Node:              *node,

--- a/tools/logdump/main.go
+++ b/tools/logdump/main.go
@@ -1,0 +1,216 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/lni/dragonboat/v3/config"
+	"github.com/lni/dragonboat/v3/internal/fileutil"
+	"github.com/lni/dragonboat/v3/internal/logdb"
+	"github.com/lni/dragonboat/v3/internal/logdb/kv/pebble"
+	"github.com/lni/dragonboat/v3/internal/vfs"
+	"github.com/lni/dragonboat/v3/raftpb"
+)
+
+const flagFilename = "dragonboat.ds"
+
+func main() {
+	if len(os.Args) < 2 {
+		printUsage()
+		os.Exit(1)
+	}
+
+	cmd := os.Args[1]
+	if len(os.Args) >= 3 {
+		arg := os.Args[2]
+		if arg == "-h" || arg == "--help" || arg == "help" {
+			switch cmd {
+			case "describe", "scan":
+				printUsage()
+				return
+			}
+		}
+	}
+
+	switch cmd {
+	case "describe":
+		if len(os.Args) < 3 {
+			fmt.Fprintf(os.Stderr, "error: data directory is required\n\n")
+			printUsage()
+			os.Exit(1)
+		}
+		runDescribe(os.Args[2], os.Args[3:])
+	case "scan":
+		if len(os.Args) < 3 {
+			fmt.Fprintf(os.Stderr, "error: data directory is required\n\n")
+			printUsage()
+			os.Exit(1)
+		}
+		runScan(os.Args[2], os.Args[3:])
+	case "-h", "--help", "help":
+		printUsage()
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n\n", cmd)
+		printUsage()
+		os.Exit(1)
+	}
+}
+
+func runDescribe(dir string, flagArgs []string) {
+	if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
+		fmt.Fprintf(os.Stderr, "error: invalid data directory %q\n", dir)
+		os.Exit(1)
+	}
+
+	fs := flag.NewFlagSet("describe", flag.ExitOnError)
+	cluster := fs.Uint64("cluster", 0, "Filter by cluster ID (optional).")
+	node := fs.Uint64("node", 0, "Filter by node ID (optional).")
+	fs.Parse(flagArgs)
+
+	s := raftpb.RaftDataStatus{}
+	if err := fileutil.GetFlagFileContent(dir, flagFilename, &s, vfs.DefaultFS); err != nil {
+		fmt.Fprintf(os.Stderr, "error reading %s: %v\n", path.Join(dir, flagFilename), err)
+	}
+
+	fmt.Println("MANIFEST:", ManifestString(&s))
+
+	db, err := logdb.OpenReadOnlyLogDB(config.GetDefaultLogDBConfig(),
+		dir, path.Join(dir, "wal"),
+		vfs.DefaultFS, pebble.PebbleReadOnlyNoLockKVStore)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error opening database: %v\n", err)
+		os.Exit(1)
+	}
+
+	d := NewDumper(db)
+	defer d.Close()
+
+	summaries, err := d.Describe(*cluster, *node)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error describing nodes: %v\n", err)
+		os.Exit(1)
+	}
+
+	PrintSummary(summaries)
+}
+
+func runScan(dir string, flagArgs []string) {
+	if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
+		fmt.Fprintf(os.Stderr, "error: invalid data directory %q\n", dir)
+		os.Exit(1)
+	}
+
+	fs := flag.NewFlagSet("scan", flag.ExitOnError)
+	cluster := fs.Uint64("cluster", 0, "Cluster ID (required).")
+	node := fs.Uint64("node", 0, "Node ID (required).")
+	from := fs.Uint64("from", 0, "Start index (inclusive, default: first available).")
+	to := fs.Uint64("to", 0, "End index (exclusive, default: last+1).")
+	index := fs.Uint64("index", 0, "Single entry shortcut (--from N --to N+1).")
+	limit := fs.Uint64("limit", 100, "Max entries to display (default: 100, 0 = unlimited).")
+	format := fs.String("format", "table", "Output format: table (default) or json.")
+	decodeEntryHeader := fs.Bool("decode-entry-header", false, "Structurally decode Cmd payloads (protobuf, snappy).")
+	decodeEntryCmd := fs.Bool("decode-entry-cmd", false, "Walk protobuf wire format in Cmd payloads (implies --decode-value).")
+
+	fs.Parse(flagArgs)
+
+	if *decodeEntryCmd {
+		*decodeEntryHeader = true
+	}
+
+	if *cluster == 0 {
+		fmt.Fprintf(os.Stderr, "error: --cluster is required and must be > 0\n")
+		os.Exit(1)
+	}
+	if *node == 0 {
+		fmt.Fprintf(os.Stderr, "error: --node is required and must be > 0\n")
+		os.Exit(1)
+	}
+
+	if *format != "table" && *format != "json" {
+		fmt.Fprintf(os.Stderr, "error: --format must be \"table\" or \"json\", got %q\n", *format)
+		os.Exit(1)
+	}
+
+	// --index is a shortcut for --from N --to N+1.
+	if *index > 0 {
+		*from = *index
+		*to = *index + 1
+	}
+
+	db, err := logdb.OpenReadOnlyLogDB(config.GetDefaultLogDBConfig(),
+		dir, path.Join(dir, "wal"),
+		vfs.DefaultFS, pebble.PebbleReadOnlyNoLockKVStore)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error opening database: %v\n", err)
+		os.Exit(1)
+	}
+
+	d := NewDumper(db)
+	defer d.Close()
+
+	result, err := d.Scan(*cluster, *node, *from, *to, *limit)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error getting entries: %v\n", err)
+		os.Exit(1)
+	}
+
+	switch *format {
+	case "json":
+		PrintScanJSON(result, *cluster, *node, *decodeEntryHeader, *decodeEntryCmd)
+	default:
+		PrintScanTable(result, *cluster, *node, *decodeEntryHeader, *decodeEntryCmd)
+	}
+}
+
+func printUsage() {
+	fmt.Print(`logdump — Dragonboat RAFT log inspection tool
+
+USAGE:
+  logdump describe <data-dir> [flags]
+  logdump scan     <data-dir> --cluster N --node N [flags]
+
+COMMANDS:
+  describe  Show available clusters, nodes, and their RAFT state.
+  scan      Pretty-print RAFT log entries with metadata.
+
+LIST FLAGS:
+  --cluster N   Filter by cluster ID (optional).
+  --node N      Filter by node ID (optional).
+
+GET FLAGS:
+  --cluster N   Cluster ID (required).
+  --node N      Node ID (required).
+  
+	--from N      Start index (inclusive, default: first available).
+  --to N        End index (exclusive, default: last+1).
+  --index N     Single entry shortcut (--from N --to N+1).
+  --limit N     Max entries to display (default: 100, 0 = unlimited).
+
+	--format fmt  Output format: table (default) or json.
+
+  --decode-entry-header Structurally decode Cmd payloads (raftpb.Entry).
+  --decode-entry-cmd Walk protobuf wire format in Cmd payloads (implies --decode-entry-header).
+
+EXAMPLES:
+  logdump describe /var/dragonboat/nodehost
+  logdump describe /var/dragonboat/nodehost --cluster 1
+  logdump scan  /var/dragonboat/nodehost --cluster 1 --node 2 --from 100 --to 200
+  logdump scan  /var/dragonboat/nodehost --cluster 1 --node 2 --index 42
+  logdump scan  /var/dragonboat/nodehost --cluster 1 --node 2 --format json
+  logdump scan  /var/dragonboat/nodehost --cluster 1 --node 2 --index 42 --format json --decode-entry-header --decode-entry-cmd
+`)
+}

--- a/tools/logdump/main.go
+++ b/tools/logdump/main.go
@@ -18,18 +18,36 @@ import (
 	"os"
 	"path"
 
-	"github.com/lni/dragonboat/v3/config"
-	"github.com/lni/dragonboat/v3/internal/fileutil"
-	"github.com/lni/dragonboat/v3/internal/logdb"
-	"github.com/lni/dragonboat/v3/internal/logdb/kv/pebble"
-	"github.com/lni/dragonboat/v3/internal/vfs"
-	"github.com/lni/dragonboat/v3/raftpb"
 	"github.com/lni/dragonboat/v3/tools/logdump/proto"
 )
 
+type DescribeConfig struct {
+	Dir     string
+	Cluster uint64
+	Node    uint64
+}
+
+type ScanConfig struct {
+	Dir     string
+	Cluster uint64
+	Node    uint64
+
+	From  uint64
+	To    uint64
+	Index uint64
+	Limit uint64
+
+	Format string
+
+	DecodeEntryHeader bool
+	DecodeEntryCmd    bool
+
+	CmdDecoder proto.CmdDecoderFunc
+}
+
 func main() {
 	if len(os.Args) < 2 {
-		printUsage()
+		PrintUsage()
 		os.Exit(1)
 	}
 
@@ -39,7 +57,7 @@ func main() {
 		if arg == "-h" || arg == "--help" || arg == "help" {
 			switch cmd {
 			case "describe", "scan":
-				printUsage()
+				PrintUsage()
 				return
 			}
 		}
@@ -49,68 +67,126 @@ func main() {
 	case "describe":
 		if len(os.Args) < 3 {
 			fmt.Fprintf(os.Stderr, "error: data directory is required\n\n")
-			printUsage()
+			PrintUsage()
 			os.Exit(1)
 		}
-		runDescribe(os.Args[2], os.Args[3:])
+		cfg, err := ParseDescribeFlags(os.Args[2], os.Args[3:])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n\n", err)
+			PrintUsage()
+			os.Exit(1)
+		}
+		DescribeCmd(cfg)
 	case "scan":
 		if len(os.Args) < 3 {
 			fmt.Fprintf(os.Stderr, "error: data directory is required\n\n")
-			printUsage()
+			PrintUsage()
 			os.Exit(1)
 		}
-		runScan(os.Args[2], os.Args[3:])
+		cfg, err := ParseScanFlags(os.Args[2], os.Args[3:])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n\n", err)
+			PrintUsage()
+			os.Exit(1)
+		}
+		ScanCmd(cfg)
 	case "-h", "--help", "help":
-		printUsage()
+		PrintUsage()
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n\n", cmd)
-		printUsage()
+		PrintUsage()
 		os.Exit(1)
 	}
 }
 
-func runDescribe(dir string, flagArgs []string) {
-	if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
-		fmt.Fprintf(os.Stderr, "error: invalid data directory %q\n", dir)
+func DescribeCmd(cfg *DescribeConfig) error {
+	ld, err := OpenLogDumpReadOnly(cfg.Dir, true)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error opening database:\n%v", err)
 		os.Exit(1)
 	}
 
-	fs := flag.NewFlagSet("describe", flag.ExitOnError)
-	cluster := fs.Uint64("cluster", 0, "Filter by cluster ID (optional).")
-	node := fs.Uint64("node", 0, "Filter by node ID (optional).")
-	fs.Parse(flagArgs)
-
-	s := raftpb.RaftDataStatus{}
-	if err := fileutil.GetFlagFileContent(dir, flagFilename, &s, vfs.DefaultFS); err != nil {
-		fmt.Fprintf(os.Stderr, "error reading %s: %v\n", path.Join(dir, flagFilename), err)
+	s, err := ld.GetRaftDataStatus()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error reading %s: %v\n", path.Join(cfg.Dir, flagFilename), err)
+		os.Exit(1)
 	}
 
 	fmt.Println("MANIFEST:", ManifestString(&s))
 
-	db, err := logdb.OpenReadOnlyLogDB(config.GetDefaultLogDBConfig(),
-		dir, path.Join(dir, "wal"),
-		vfs.DefaultFS, pebble.PebbleReadOnlyNoLockKVStore)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error opening database: %v\n", err)
-		os.Exit(1)
-	}
-
-	d := NewDumper(db)
+	d := ld.Dumper()
 	defer d.Close()
 
-	summaries, err := d.Describe(*cluster, *node)
+	summaries, err := d.Describe(cfg.Cluster, cfg.Node)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error describing nodes: %v\n", err)
 		os.Exit(1)
 	}
 
 	PrintSummary(summaries)
+
+	return nil
 }
 
-func runScan(dir string, flagArgs []string) {
-	if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
-		fmt.Fprintf(os.Stderr, "error: invalid data directory %q\n", dir)
+func ScanCmd(cfg *ScanConfig) error {
+	ld, err := OpenLogDumpReadOnly(cfg.Dir, true)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error opening database:\n%v", err)
 		os.Exit(1)
+	}
+
+	d := ld.Dumper()
+	defer d.Close()
+
+	result, err := d.Scan(cfg.Cluster, cfg.Node, cfg.From, cfg.To, cfg.Limit)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error getting entries: %v\n", err)
+		os.Exit(1)
+	}
+
+	var opts []proto.DecodeOption
+	if cfg.DecodeEntryHeader {
+		opts = append(opts, proto.WithEntryHeaderDecode())
+	}
+	if cfg.DecodeEntryCmd {
+		opts = append(opts, proto.WithEntryCmdDecode())
+	}
+	if cfg.CmdDecoder != nil {
+		opts = append(opts, proto.WithCmdDecoder(cfg.CmdDecoder))
+	}
+
+	switch cfg.Format {
+	case "json":
+		PrintScanJSON(result, cfg.Cluster, cfg.Node, opts...)
+	default:
+		PrintScanTable(result, cfg.Cluster, cfg.Node, opts...)
+	}
+
+	return nil
+}
+
+func ParseDescribeFlags(dir string, flagArgs []string) (*DescribeConfig, error) {
+	if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
+		return nil, fmt.Errorf("invalid data directory %q", dir)
+	}
+
+	fs := flag.NewFlagSet("describe", flag.ExitOnError)
+	cluster := fs.Uint64("cluster", 0, "Filter by cluster ID (optional).")
+	node := fs.Uint64("node", 0, "Filter by node ID (optional).")
+	if err := fs.Parse(flagArgs); err != nil {
+		return nil, err
+	}
+
+	return &DescribeConfig{
+		Dir:     dir,
+		Cluster: *cluster,
+		Node:    *node,
+	}, nil
+}
+
+func ParseScanFlags(dir string, flagArgs []string) (*ScanConfig, error) {
+	if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
+		return nil, fmt.Errorf("invalid data directory %q", dir)
 	}
 
 	fs := flag.NewFlagSet("scan", flag.ExitOnError)
@@ -124,24 +200,23 @@ func runScan(dir string, flagArgs []string) {
 	decodeEntryHeader := fs.Bool("decode-entry-header", false, "Structurally decode Cmd payloads (protobuf, snappy).")
 	decodeEntryCmd := fs.Bool("decode-entry-cmd", false, "Walk protobuf wire format in Cmd payloads (implies --decode-value).")
 
-	fs.Parse(flagArgs)
+	if err := fs.Parse(flagArgs); err != nil {
+		return nil, err
+	}
 
 	if *decodeEntryCmd {
 		*decodeEntryHeader = true
 	}
 
 	if *cluster == 0 {
-		fmt.Fprintf(os.Stderr, "error: --cluster is required and must be > 0\n")
-		os.Exit(1)
+		return nil, fmt.Errorf("--cluster is required and must be > 0")
 	}
 	if *node == 0 {
-		fmt.Fprintf(os.Stderr, "error: --node is required and must be > 0\n")
-		os.Exit(1)
+		return nil, fmt.Errorf("--node is required and must be > 0")
 	}
 
 	if *format != "table" && *format != "json" {
-		fmt.Fprintf(os.Stderr, "error: --format must be \"table\" or \"json\", got %q\n", *format)
-		os.Exit(1)
+		return nil, fmt.Errorf("--format must be \"table\" or \"json\", got %q", *format)
 	}
 
 	// --index is a shortcut for --from N --to N+1.
@@ -150,40 +225,21 @@ func runScan(dir string, flagArgs []string) {
 		*to = *index + 1
 	}
 
-	db, err := logdb.OpenReadOnlyLogDB(config.GetDefaultLogDBConfig(),
-		dir, path.Join(dir, "wal"),
-		vfs.DefaultFS, pebble.PebbleReadOnlyNoLockKVStore)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error opening database: %v\n", err)
-		os.Exit(1)
-	}
-
-	d := NewDumper(db)
-	defer d.Close()
-
-	result, err := d.Scan(*cluster, *node, *from, *to, *limit)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error getting entries: %v\n", err)
-		os.Exit(1)
-	}
-
-	var opts []proto.DecodeOption
-	if *decodeEntryHeader {
-		opts = append(opts, proto.WithEntryHeaderDecode())
-	}
-	if *decodeEntryCmd {
-		opts = append(opts, proto.WithEntryCmdDecode())
-	}
-
-	switch *format {
-	case "json":
-		PrintScanJSON(result, *cluster, *node, opts...)
-	default:
-		PrintScanTable(result, *cluster, *node, opts...)
-	}
+	return &ScanConfig{
+		Dir:               dir,
+		Cluster:           *cluster,
+		Node:              *node,
+		From:              *from,
+		To:                *to,
+		Index:             *index,
+		Limit:             *limit,
+		Format:            *format,
+		DecodeEntryHeader: *decodeEntryHeader,
+		DecodeEntryCmd:    *decodeEntryCmd,
+	}, nil
 }
 
-func printUsage() {
+func PrintUsage() {
 	fmt.Print(`logdump — Dragonboat RAFT log inspection tool
 
 USAGE:

--- a/tools/logdump/main.go
+++ b/tools/logdump/main.go
@@ -24,9 +24,8 @@ import (
 	"github.com/lni/dragonboat/v3/internal/logdb/kv/pebble"
 	"github.com/lni/dragonboat/v3/internal/vfs"
 	"github.com/lni/dragonboat/v3/raftpb"
+	"github.com/lni/dragonboat/v3/tools/logdump/proto"
 )
-
-const flagFilename = "dragonboat.ds"
 
 func main() {
 	if len(os.Args) < 2 {
@@ -168,11 +167,19 @@ func runScan(dir string, flagArgs []string) {
 		os.Exit(1)
 	}
 
+	var opts []proto.DecodeOption
+	if *decodeEntryHeader {
+		opts = append(opts, proto.WithEntryHeaderDecode())
+	}
+	if *decodeEntryCmd {
+		opts = append(opts, proto.WithEntryCmdDecode())
+	}
+
 	switch *format {
 	case "json":
-		PrintScanJSON(result, *cluster, *node, *decodeEntryHeader, *decodeEntryCmd)
+		PrintScanJSON(result, *cluster, *node, opts...)
 	default:
-		PrintScanTable(result, *cluster, *node, *decodeEntryHeader, *decodeEntryCmd)
+		PrintScanTable(result, *cluster, *node, opts...)
 	}
 }
 
@@ -194,13 +201,13 @@ LIST FLAGS:
 GET FLAGS:
   --cluster N   Cluster ID (required).
   --node N      Node ID (required).
-  
-	--from N      Start index (inclusive, default: first available).
+
+  --from N      Start index (inclusive, default: first available).
   --to N        End index (exclusive, default: last+1).
   --index N     Single entry shortcut (--from N --to N+1).
   --limit N     Max entries to display (default: 100, 0 = unlimited).
 
-	--format fmt  Output format: table (default) or json.
+  --format fmt  Output format: table (default) or json.
 
   --decode-entry-header Structurally decode Cmd payloads (raftpb.Entry).
   --decode-entry-cmd Walk protobuf wire format in Cmd payloads (implies --decode-entry-header).

--- a/tools/logdump/print.go
+++ b/tools/logdump/print.go
@@ -111,7 +111,7 @@ func PrintSummary(summaries []NodeSummary) {
 
 // PrintScanTable prints the state, snapshots, and entries for a node in a
 // human-readable kebab-section format.
-func PrintScanTable(r *ScanResult, clusterID, nodeID uint64, decodeEntryHeader, decodeEntryCmd bool) {
+func PrintScanTable(r *ScanResult, clusterID, nodeID uint64, opts ...proto.DecodeOption) {
 	// ── state ──
 	fmt.Printf("── state: cluster=%d node=%d ──\n", clusterID, nodeID)
 	fmt.Printf("Term: %d, Vote: %d, Commit: %d\n\n", r.State.Term, r.State.Vote, r.State.Commit)
@@ -143,11 +143,7 @@ func PrintScanTable(r *ScanResult, clusterID, nodeID uint64, decodeEntryHeader, 
 				typeName = "── " + typeName
 			}
 			cmdStr := formatCmd(e)
-			if decodeEntryHeader {
-				var opts []proto.DecodeOption
-				if decodeEntryCmd {
-					opts = append(opts, proto.WithEntryCmdDecode())
-				}
+			if len(opts) > 0 {
 				if d, err := proto.DecodeCmd(e, opts...); err != nil {
 					cmdStr = fmt.Sprintf("<decode error: %v>", err)
 				} else {
@@ -197,7 +193,7 @@ type jsonResult struct {
 }
 
 // PrintScanJSON prints the GetEntries result as compact JSON to stdout.
-func PrintScanJSON(r *ScanResult, clusterID, nodeID uint64, decodeEntryHeader, decodeEntryCmd bool) {
+func PrintScanJSON(r *ScanResult, clusterID, nodeID uint64, opts ...proto.DecodeOption) {
 	out := jsonResult{
 		ClusterID:  clusterID,
 		NodeID:     nodeID,
@@ -221,12 +217,7 @@ func PrintScanJSON(r *ScanResult, clusterID, nodeID uint64, decodeEntryHeader, d
 	for _, e := range r.Entries {
 		var cmdField interface{}
 
-		if decodeEntryHeader {
-			var opts []proto.DecodeOption
-			if decodeEntryCmd {
-				opts = append(opts, proto.WithEntryCmdDecode())
-			}
-
+		if len(opts) > 0 {
 			d, err := proto.DecodeCmd(e, opts...)
 			if err != nil {
 				cmdField = map[string]string{"error": err.Error()}

--- a/tools/logdump/print.go
+++ b/tools/logdump/print.go
@@ -17,7 +17,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"os"
+	"io"
 	"text/tabwriter"
 
 	pb "github.com/lni/dragonboat/v3/raftpb"
@@ -91,9 +91,9 @@ func ManifestString(m *pb.RaftDataStatus) string {
 
 // PrintSummary prints a table of NodeSummary rows to stdout using aligned
 // columns.
-func PrintSummary(summaries []NodeSummary) {
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-	fmt.Fprintln(w, "CLUSTER\tNODE\tTERM\tVOTE\tCOMMIT\tENTRIES\tRANGE\tSNAPSHOTS\tBOOTSTRAP")
+func PrintSummary(w io.Writer, summaries []NodeSummary) {
+	tabw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(tabw, "CLUSTER\tNODE\tTERM\tVOTE\tCOMMIT\tENTRIES\tRANGE\tSNAPSHOTS\tBOOTSTRAP")
 	for _, s := range summaries {
 		rng := ""
 		if s.EntryCount > 0 {
@@ -101,41 +101,41 @@ func PrintSummary(summaries []NodeSummary) {
 		} else {
 			rng = "(empty)"
 		}
-		fmt.Fprintf(w, "%d\t%d\t%d\t%d\t%d\t%d\t%s\t%d\t%s\n",
+		fmt.Fprintf(tabw, "%d\t%d\t%d\t%d\t%d\t%d\t%s\t%d\t%s\n",
 			s.ClusterID, s.NodeID,
 			s.Term, s.Vote, s.Commit,
 			s.EntryCount, rng, s.SnapshotCnt, s.Bootstrap)
 	}
-	w.Flush()
+	tabw.Flush()
 }
 
 // PrintScanTable prints the state, snapshots, and entries for a node in a
 // human-readable kebab-section format.
-func PrintScanTable(r *ScanResult, clusterID, nodeID uint64, opts ...proto.DecodeOption) {
+func PrintScanTable(w io.Writer, r *ScanResult, clusterID, nodeID uint64, opts ...proto.DecodeOption) {
 	// ── state ──
-	fmt.Printf("── state: cluster=%d node=%d ──\n", clusterID, nodeID)
-	fmt.Printf("Term: %d, Vote: %d, Commit: %d\n\n", r.State.Term, r.State.Vote, r.State.Commit)
+	fmt.Fprintf(w, "── state: cluster=%d node=%d ──\n", clusterID, nodeID)
+	fmt.Fprintf(w, "Term: %d, Vote: %d, Commit: %d\n\n", r.State.Term, r.State.Vote, r.State.Commit)
 
 	// ── snapshots ──
 	if len(r.Snapshots) > 0 {
-		fmt.Printf("── snapshots ──\n")
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-		fmt.Fprintln(w, "INDEX\tTERM\tMEMBERS")
+		fmt.Fprintf(w, "── snapshots ──\n")
+		tabw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+		fmt.Fprintln(tabw, "INDEX\tTERM\tMEMBERS")
 		for _, snap := range r.Snapshots {
 			n := len(snap.Membership.Addresses)
-			fmt.Fprintf(w, "%d\t%d\t%d addrs\n", snap.Index, snap.Term, n)
+			fmt.Fprintf(tabw, "%d\t%d\t%d addrs\n", snap.Index, snap.Term, n)
 		}
-		w.Flush()
-		fmt.Println()
+		tabw.Flush()
+		fmt.Fprintln(w)
 	}
 
 	// ── entries ──
-	fmt.Printf("── entries ──\n")
+	fmt.Fprintf(w, "── entries ──\n")
 	if len(r.Entries) == 0 {
-		fmt.Println("(no entries)")
+		fmt.Fprintln(w, "(no entries)")
 	} else {
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-		fmt.Fprintln(w, "INDEX\tTERM\tTYPE\tKEY\tCLIENT\tSERIES\tRESPTO\tCMD")
+		tabw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+		fmt.Fprintln(tabw, "INDEX\tTERM\tTYPE\tKEY\tCLIENT\tSERIES\tRESPTO\tCMD")
 		for _, e := range r.Entries {
 			typeName := e.Type.String()
 			// Visually dim entries from internal Raft layers.
@@ -152,12 +152,12 @@ func PrintScanTable(r *ScanResult, clusterID, nodeID uint64, opts ...proto.Decod
 			}
 			keyHex := fmt.Sprintf("%016x", e.Key)
 			clientHex := fmt.Sprintf("%016x", e.ClientID)
-			fmt.Fprintf(w, "%d\t%d\t%s\t0x%s\t0x%s\t%d\t%d\t%s\n",
+			fmt.Fprintf(tabw, "%d\t%d\t%s\t0x%s\t0x%s\t%d\t%d\t%s\n",
 				e.Index, e.Term, typeName,
 				keyHex, clientHex, e.SeriesID, e.RespondedTo,
 				cmdStr)
 		}
-		w.Flush()
+		tabw.Flush()
 	}
 }
 
@@ -193,7 +193,7 @@ type jsonResult struct {
 }
 
 // PrintScanJSON prints the GetEntries result as compact JSON to stdout.
-func PrintScanJSON(r *ScanResult, clusterID, nodeID uint64, opts ...proto.DecodeOption) {
+func PrintScanJSON(w io.Writer, r *ScanResult, clusterID, nodeID uint64, opts ...proto.DecodeOption) {
 	out := jsonResult{
 		ClusterID:  clusterID,
 		NodeID:     nodeID,
@@ -240,7 +240,7 @@ func PrintScanJSON(r *ScanResult, clusterID, nodeID uint64, opts ...proto.Decode
 		})
 	}
 
-	enc := json.NewEncoder(os.Stdout)
+	enc := json.NewEncoder(w)
 	enc.SetIndent("", "")
 	enc.Encode(out)
 }

--- a/tools/logdump/print.go
+++ b/tools/logdump/print.go
@@ -1,0 +1,255 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	pb "github.com/lni/dragonboat/v3/raftpb"
+	"github.com/lni/dragonboat/v3/tools/logdump/proto"
+)
+
+// isPrintable returns true when s contains only printable ASCII characters
+// (bytes 0x20-0x7E inclusive).
+func isPrintable(s string) bool {
+	for _, r := range s {
+		if r < 32 || r > 126 {
+			return false
+		}
+	}
+	return true
+}
+
+// formatCmd returns a human-friendly representation of an entry's Cmd field.
+//
+//   - ConfigChange entries with printable Cmd are shown inline.
+//   - Session-management entries get descriptive labels.
+//   - Short printable payloads are shown as text.
+//   - Binary payloads are hex-dumped (first 6 bytes).
+func formatCmd(e pb.Entry) string {
+	// ConfigChange with printable Cmd — show as text.
+	if e.IsConfigChange() && len(e.Cmd) > 0 && isPrintable(string(e.Cmd)) {
+		return string(e.Cmd)
+	}
+	// Client session management.
+	if e.IsNewSessionRequest() {
+		return "(new session)"
+	}
+	if e.IsEndOfSessionRequest() {
+		return "(end session)"
+	}
+	// NoOP session with empty payload.
+	if e.IsNoOPSession() && len(e.Cmd) == 0 {
+		return "(no-op)"
+	}
+	// Truly empty entry (not config change, not session managed).
+	if e.IsEmpty() {
+		return "(empty)"
+	}
+	// Short printable payload — show inline.
+	if len(e.Cmd) <= 40 && isPrintable(string(e.Cmd)) {
+		return string(e.Cmd)
+	}
+	// Binary payload — hex dump first 6 bytes.
+	n := len(e.Cmd)
+	if n > 6 {
+		return fmt.Sprintf("%x... (%d B)", e.Cmd[:6], n)
+	}
+	return fmt.Sprintf("%x (%d B)", e.Cmd, n)
+}
+
+func ManifestString(m *pb.RaftDataStatus) string {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "Address=%s, ", m.Address)
+	fmt.Fprintf(&buf, "BinVer=%d, ", m.BinVer)
+	fmt.Fprintf(&buf, "HardHash=%d, ", m.HardHash)
+	fmt.Fprintf(&buf, "LogdbType=%s, ", m.LogdbType)
+	fmt.Fprintf(&buf, "Hostname=%s, ", m.Hostname)
+	fmt.Fprintf(&buf, "DeploymentId=%d, ", m.DeploymentId)
+	fmt.Fprintf(&buf, "StepWorkerCount=%d, ", m.StepWorkerCount)
+	fmt.Fprintf(&buf, "LogdbShardCount=%d, ", m.LogdbShardCount)
+	fmt.Fprintf(&buf, "MaxSessionCount=%d, ", m.MaxSessionCount)
+	fmt.Fprintf(&buf, "EntryBatchSize=%d, ", m.EntryBatchSize)
+	fmt.Fprintf(&buf, "AddressByNodeHostId=%v", m.AddressByNodeHostId)
+	return buf.String()
+}
+
+// PrintSummary prints a table of NodeSummary rows to stdout using aligned
+// columns.
+func PrintSummary(summaries []NodeSummary) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "CLUSTER\tNODE\tTERM\tVOTE\tCOMMIT\tENTRIES\tRANGE\tSNAPSHOTS\tBOOTSTRAP")
+	for _, s := range summaries {
+		rng := ""
+		if s.EntryCount > 0 {
+			rng = fmt.Sprintf("[%d..%d]", s.FirstIndex, s.LastIndex)
+		} else {
+			rng = "(empty)"
+		}
+		fmt.Fprintf(w, "%d\t%d\t%d\t%d\t%d\t%d\t%s\t%d\t%s\n",
+			s.ClusterID, s.NodeID,
+			s.Term, s.Vote, s.Commit,
+			s.EntryCount, rng, s.SnapshotCnt, s.Bootstrap)
+	}
+	w.Flush()
+}
+
+// PrintScanTable prints the state, snapshots, and entries for a node in a
+// human-readable kebab-section format.
+func PrintScanTable(r *ScanResult, clusterID, nodeID uint64, decodeEntryHeader, decodeEntryCmd bool) {
+	// ── state ──
+	fmt.Printf("── state: cluster=%d node=%d ──\n", clusterID, nodeID)
+	fmt.Printf("Term: %d, Vote: %d, Commit: %d\n\n", r.State.Term, r.State.Vote, r.State.Commit)
+
+	// ── snapshots ──
+	if len(r.Snapshots) > 0 {
+		fmt.Printf("── snapshots ──\n")
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		fmt.Fprintln(w, "INDEX\tTERM\tMEMBERS")
+		for _, snap := range r.Snapshots {
+			n := len(snap.Membership.Addresses)
+			fmt.Fprintf(w, "%d\t%d\t%d addrs\n", snap.Index, snap.Term, n)
+		}
+		w.Flush()
+		fmt.Println()
+	}
+
+	// ── entries ──
+	fmt.Printf("── entries ──\n")
+	if len(r.Entries) == 0 {
+		fmt.Println("(no entries)")
+	} else {
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		fmt.Fprintln(w, "INDEX\tTERM\tTYPE\tKEY\tCLIENT\tSERIES\tRESPTO\tCMD")
+		for _, e := range r.Entries {
+			typeName := e.Type.String()
+			// Visually dim entries from internal Raft layers.
+			if e.Type == pb.MetadataEntry || e.Type == pb.EncodedEntry {
+				typeName = "── " + typeName
+			}
+			cmdStr := formatCmd(e)
+			if decodeEntryHeader {
+				var opts []proto.DecodeOption
+				if decodeEntryCmd {
+					opts = append(opts, proto.WithEntryCmdDecode())
+				}
+				if d, err := proto.DecodeCmd(e, opts...); err != nil {
+					cmdStr = fmt.Sprintf("<decode error: %v>", err)
+				} else {
+					cmdStr = d.Summary
+				}
+			}
+			keyHex := fmt.Sprintf("%016x", e.Key)
+			clientHex := fmt.Sprintf("%016x", e.ClientID)
+			fmt.Fprintf(w, "%d\t%d\t%s\t0x%s\t0x%s\t%d\t%d\t%s\n",
+				e.Index, e.Term, typeName,
+				keyHex, clientHex, e.SeriesID, e.RespondedTo,
+				cmdStr)
+		}
+		w.Flush()
+	}
+}
+
+type jsonSnapshot struct {
+	Index   uint64 `json:"index"`
+	Term    uint64 `json:"term"`
+	Members int    `json:"members"`
+}
+
+type jsonEntry struct {
+	Index       uint64      `json:"index"`
+	Term        uint64      `json:"term"`
+	Type        string      `json:"type"`
+	Key         uint64      `json:"key"`
+	ClientID    uint64      `json:"client_id"`
+	SeriesID    uint64      `json:"series_id"`
+	RespondedTo uint64      `json:"responded_to"`
+	Cmd         interface{} `json:"cmd"`
+}
+
+type jsonResult struct {
+	ClusterID  uint64         `json:"cluster_id"`
+	NodeID     uint64         `json:"node_id"`
+	State      pb.State       `json:"state"`
+	Snapshots  []jsonSnapshot `json:"snapshots,omitempty"`
+	Entries    []jsonEntry    `json:"entries,omitempty"`
+	From       uint64         `json:"from"`
+	To         uint64         `json:"to"`
+	Limit      uint64         `json:"limit"`
+	FirstIndex uint64         `json:"first_index"`
+	LastIndex  uint64         `json:"last_index"`
+	EntryCount uint64         `json:"entry_count"`
+}
+
+// PrintScanJSON prints the GetEntries result as compact JSON to stdout.
+func PrintScanJSON(r *ScanResult, clusterID, nodeID uint64, decodeEntryHeader, decodeEntryCmd bool) {
+	out := jsonResult{
+		ClusterID:  clusterID,
+		NodeID:     nodeID,
+		State:      r.State,
+		From:       r.From,
+		To:         r.To,
+		Limit:      r.Limit,
+		FirstIndex: r.FirstIndex,
+		LastIndex:  r.LastIndex,
+		EntryCount: r.EntryCount,
+	}
+
+	for _, snap := range r.Snapshots {
+		out.Snapshots = append(out.Snapshots, jsonSnapshot{
+			Index:   snap.Index,
+			Term:    snap.Term,
+			Members: len(snap.Membership.Addresses),
+		})
+	}
+
+	for _, e := range r.Entries {
+		var cmdField interface{}
+
+		if decodeEntryHeader {
+			var opts []proto.DecodeOption
+			if decodeEntryCmd {
+				opts = append(opts, proto.WithEntryCmdDecode())
+			}
+
+			d, err := proto.DecodeCmd(e, opts...)
+			if err != nil {
+				cmdField = map[string]string{"error": err.Error()}
+			} else {
+				cmdField = d
+			}
+		} else {
+			cmdField = hex.EncodeToString(e.Cmd)
+		}
+
+		out.Entries = append(out.Entries, jsonEntry{
+			Index:       e.Index,
+			Term:        e.Term,
+			Type:        e.Type.String(),
+			Key:         e.Key,
+			ClientID:    e.ClientID,
+			SeriesID:    e.SeriesID,
+			RespondedTo: e.RespondedTo,
+			Cmd:         cmdField,
+		})
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "")
+	enc.Encode(out)
+}

--- a/tools/logdump/proto/decode.go
+++ b/tools/logdump/proto/decode.go
@@ -68,8 +68,10 @@ type DecodedCmd struct {
 type decodeConfig struct {
 	decodeEntryCmd bool
 
-	cmdDecoder func([]byte) (msg ProtoMessage, sum string, err error)
+	cmdDecoder CmdDecoderFunc
 }
+
+type CmdDecoderFunc func([]byte) (msg ProtoMessage, sum string, err error)
 
 // DecodeOption configures DecodeCmd behavior.
 type DecodeOption func(*decodeConfig)
@@ -90,7 +92,7 @@ func WithEntryCmdDecode() DecodeOption {
 }
 
 // WithCmdDecoder sets the function to decode a cmd field.
-func WithCmdDecoder(f func([]byte) (ProtoMessage, string, error)) DecodeOption {
+func WithCmdDecoder(f CmdDecoderFunc) DecodeOption {
 	return func(c *decodeConfig) {
 		c.cmdDecoder = f
 	}

--- a/tools/logdump/proto/decode.go
+++ b/tools/logdump/proto/decode.go
@@ -1,0 +1,355 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proto
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/golang/snappy"
+
+	pb "github.com/lni/dragonboat/v3/raftpb"
+)
+
+// CmdKind classifies a decoded Entry.Cmd payload.
+type CmdKind int
+
+const (
+	KindEmpty        CmdKind = iota // Cmd is nil or zero-length
+	KindSession                     // Session-managed (new/end/no-op), identified by SeriesID
+	KindConfigChange                // pb.ConfigChange unmarshaled successfully
+	KindEncodedEntry                // EncodedEntry decompressed
+	KindRaw                         // Raw application bytes (fallback)
+)
+
+func (k CmdKind) String() string {
+	switch k {
+	case KindEmpty:
+		return "empty"
+	case KindSession:
+		return "session"
+	case KindConfigChange:
+		return "config_change"
+	case KindEncodedEntry:
+		return "encoded_entry"
+	case KindRaw:
+		return "raw"
+	default:
+		return "unknown"
+	}
+}
+
+// MarshalJSON implements json.Marshaler for human-readable kind strings.
+func (k CmdKind) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("%q", k.String())), nil
+}
+
+// DecodedCmd holds the structured result of decoding an Entry's Cmd field.
+// Exactly one detail field is populated depending on Kind.
+type DecodedCmd struct {
+	Kind         CmdKind             `json:"kind"`
+	Summary      string              `json:"-"` // one-line for table CMD column
+	ConfigChange *ConfigChangeDetail `json:"config_change,omitempty"`
+	EncodedEntry *EncodedEntryDetail `json:"encoded_entry,omitempty"`
+	RawHex       string              `json:"raw_hex,omitempty"`
+	ProtoMessage ProtoMessage        `json:"proto_message,omitempty"`
+}
+
+type decodeConfig struct {
+	walkEntryCmd bool
+}
+
+// DecodeOption configures DecodeCmd behavior.
+type DecodeOption func(*decodeConfig)
+
+// WithEntryCmdDecode enables protobuf payload walking on EncodedEntry
+// and raw Cmd fields via WalkProtoMessage.
+func WithEntryCmdDecode() DecodeOption {
+	return func(c *decodeConfig) {
+		c.walkEntryCmd = true
+	}
+}
+
+// ConfigChangeDetail holds the decoded fields of a pb.ConfigChange.
+type ConfigChangeDetail struct {
+	ConfigChangeID uint64 `json:"config_change_id"`
+	Type           string `json:"type"`
+	NodeID         uint64 `json:"node_id"`
+	Address        string `json:"address,omitempty"`
+	Initialize     bool   `json:"initialize"`
+}
+
+// EncodedEntryDetail holds the decoded fields of an EncodedEntry payload.
+type EncodedEntryDetail struct {
+	Version      uint8        `json:"version"`
+	Compression  string       `json:"compression"`
+	Size         int          `json:"size"`
+	PayloadHex   string       `json:"payload_hex,omitempty"`
+	PayloadText  string       `json:"payload_text,omitempty"`
+	ProtoMessage ProtoMessage `json:"proto_message,omitempty"`
+}
+
+func configChangeTypeName(t pb.ConfigChangeType) string {
+	switch t {
+	case pb.AddNode:
+		return "AddNode"
+	case pb.RemoveNode:
+		return "RemoveNode"
+	case pb.AddObserver:
+		return "AddObserver"
+	case pb.AddWitness:
+		return "AddWitness"
+	default:
+		return fmt.Sprintf("ConfigChangeType(%d)", t)
+	}
+}
+
+func isPrintable(s string) bool {
+	for _, r := range s {
+		if r < 32 || r > 126 {
+			return false
+		}
+	}
+	return true
+}
+
+// Encoded entry header constants (mirrors internal/rsm/encoded.go).
+const (
+	eeV0            uint8 = 0 << 4
+	eeVersionMask   uint8 = 15 << 4
+	eeCompMask      uint8 = 7 << 1
+	eeNoCompression uint8 = 0 << 1
+	eeSnappy        uint8 = 1 << 1
+)
+
+// DecodeCmd interprets a single Entry's Cmd field based on Entry.Type
+// and Entry.SeriesID. Returns nil error even for KindRaw; errors are
+// reserved for actual decode failures (malformed protobuf, bad snappy).
+//
+// Use WithEntryProto() to enable protobuf payload walking.
+func DecodeCmd(e pb.Entry, opts ...DecodeOption) (*DecodedCmd, error) {
+	cfg := &decodeConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	// 1. Session gating (runs first — session entries can have arbitrary Cmd).
+	if e.IsNewSessionRequest() {
+		return &DecodedCmd{Kind: KindSession, Summary: "(new session)"}, nil
+	}
+	if e.IsEndOfSessionRequest() {
+		return &DecodedCmd{Kind: KindSession, Summary: "(end session)"}, nil
+	}
+	if e.IsSessionManaged() && e.IsNoOPSession() && len(e.Cmd) == 0 {
+		return &DecodedCmd{Kind: KindSession, Summary: "(no-op)"}, nil
+	}
+
+	// 2. Type-specific decode before empty check —
+	// EncodedEntry/ConfigChangeEntry with nil/empty Cmd is an error, not KindEmpty.
+	switch e.Type {
+	case pb.ConfigChangeEntry:
+		return decodeConfigChange(e.Cmd)
+	case pb.EncodedEntry:
+		return decodeEncodedEntry(e.Cmd, cfg)
+	}
+
+	// 3. Empty.
+	if e.IsEmpty() {
+		return &DecodedCmd{Kind: KindEmpty, Summary: "(empty)"}, nil
+	}
+	if len(e.Cmd) == 0 {
+		return &DecodedCmd{Kind: KindEmpty, Summary: "(empty)"}, nil
+	}
+
+	// 4. Raw fallback (ApplicationEntry, MetadataEntry, etc.).
+	return decodeRaw(e.Cmd, cfg), nil
+}
+
+func decodeConfigChange(cmd []byte) (*DecodedCmd, error) {
+	var cc pb.ConfigChange
+	if err := cc.Unmarshal(cmd); err != nil {
+		return nil, fmt.Errorf("config change unmarshal: %w", err)
+	}
+
+	detail := &ConfigChangeDetail{
+		ConfigChangeID: cc.ConfigChangeId,
+		Type:           configChangeTypeName(cc.Type),
+		NodeID:         cc.NodeID,
+		Address:        cc.Address,
+		Initialize:     cc.Initialize,
+	}
+
+	summary := fmt.Sprintf("ConfigChange: %s node=%d", detail.Type, detail.NodeID)
+	if detail.Address != "" {
+		summary += fmt.Sprintf(" addr=%s", detail.Address)
+	}
+
+	return &DecodedCmd{
+		Kind:         KindConfigChange,
+		Summary:      summary,
+		ConfigChange: detail,
+	}, nil
+}
+
+func decodeEncodedEntry(cmd []byte, cfg *decodeConfig) (*DecodedCmd, error) {
+	if len(cmd) < 1 {
+		return nil, fmt.Errorf("encoded entry too short: %d bytes", len(cmd))
+	}
+
+	header := cmd[0]
+	ver := header & eeVersionMask
+	comp := header & eeCompMask
+
+	if ver != eeV0 {
+		// Unknown version — fall back to raw with note.
+		d := decodeRaw(cmd, cfg)
+		d.Summary = fmt.Sprintf("[v%d unknown] %s", ver>>4, d.Summary)
+		return d, nil
+	}
+
+	detail := &EncodedEntryDetail{Version: 0}
+
+	switch comp {
+	case eeNoCompression:
+		detail.Compression = "none"
+		payload := cmd[1:]
+		detail.Size = len(payload)
+		if cfg.walkEntryCmd {
+			if pm, err := WalkProtoMessage(payload); err == nil {
+				detail.ProtoMessage = pm
+			}
+		}
+		if detail.ProtoMessage == nil {
+			detail.PayloadHex = hex.EncodeToString(payload)
+			if isPrintable(string(payload)) {
+				detail.PayloadText = string(payload)
+			}
+		}
+		summary := fmt.Sprintf("[v0 uncompressed] %d B", detail.Size)
+		return &DecodedCmd{
+			Kind:         KindEncodedEntry,
+			Summary:      summary,
+			EncodedEntry: detail,
+		}, nil
+
+	case eeSnappy:
+		detail.Compression = "snappy"
+		decodedLen, err := snappy.DecodedLen(cmd[1:])
+		if err != nil {
+			return nil, fmt.Errorf("snappy decoded length: %w", err)
+		}
+		dst := make([]byte, decodedLen)
+		result, err := snappy.Decode(dst, cmd[1:])
+		if err != nil {
+			return nil, fmt.Errorf("snappy decode: %w", err)
+		}
+		detail.Size = len(result)
+		if cfg.walkEntryCmd {
+			if pm, err := WalkProtoMessage(result); err == nil {
+				detail.ProtoMessage = pm
+			}
+		}
+		if detail.ProtoMessage == nil {
+			detail.PayloadHex = hex.EncodeToString(result)
+			if isPrintable(string(result)) {
+				detail.PayloadText = string(result)
+			}
+		}
+		summary := fmt.Sprintf("[v0 snappy] %d B", detail.Size)
+		return &DecodedCmd{
+			Kind:         KindEncodedEntry,
+			Summary:      summary,
+			EncodedEntry: detail,
+		}, nil
+
+	default:
+		d := decodeRaw(cmd, cfg)
+		d.Summary = fmt.Sprintf("[compression=%d unknown] %s", comp>>1, d.Summary)
+		return d, nil
+	}
+}
+
+func decodeRaw(cmd []byte, cfg *decodeConfig) *DecodedCmd {
+	summary := formatRaw(cmd)
+	d := &DecodedCmd{
+		Kind:    KindRaw,
+		Summary: summary,
+		RawHex:  hex.EncodeToString(cmd),
+	}
+	if cfg.walkEntryCmd && len(cmd) > 0 {
+		if pm, err := WalkProtoMessage(cmd); err == nil {
+			d.ProtoMessage = pm
+		}
+	}
+	return d
+}
+
+// formatRaw mirrors the existing formatCmd heuristic for raw bytes.
+func formatRaw(cmd []byte) string {
+	if len(cmd) <= 40 && isPrintable(string(cmd)) {
+		return string(cmd)
+	}
+	n := len(cmd)
+	if n > 6 {
+		return fmt.Sprintf("%x... (%d B)", cmd[:6], n)
+	}
+	return fmt.Sprintf("%x (%d B)", cmd, n)
+}
+
+// DecodeValue parses raw LogDB value bytes into entries.
+// Auto-detects plain (Colfer) vs batched (protobuf framing + Colfer entries).
+func DecodeValue(raw []byte) ([]pb.Entry, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("empty value")
+	}
+
+	// Detection: first byte 0x0a = protobuf field 1, wire type 2 (EntryBatch).
+	// Colfer field indices for Entry are 0-7; 0x0a is never a valid index byte.
+	if raw[0] == 0x0a {
+		return decodeBatch(raw)
+	}
+	return decodePlain(raw)
+}
+
+func decodePlain(raw []byte) ([]pb.Entry, error) {
+	var e pb.Entry
+	if err := e.Unmarshal(raw); err != nil {
+		return nil, fmt.Errorf("plain entry unmarshal: %w", err)
+	}
+	return []pb.Entry{e}, nil
+}
+
+func decodeBatch(raw []byte) ([]pb.Entry, error) {
+	var eb pb.EntryBatch
+	if err := eb.Unmarshal(raw); err != nil {
+		return nil, fmt.Errorf("batch unmarshal: %w", err)
+	}
+	restoreBatchFields(&eb)
+	return eb.Entries, nil
+}
+
+// restoreBatchFields reconstructs zeroed Term/Index for entries[1:]
+// when the batch used field compaction (detected via last entry Term==0).
+func restoreBatchFields(eb *pb.EntryBatch) {
+	if len(eb.Entries) <= 1 {
+		return
+	}
+	if eb.Entries[len(eb.Entries)-1].Term == 0 {
+		term := eb.Entries[0].Term
+		idx := eb.Entries[0].Index
+		for i := 1; i < len(eb.Entries); i++ {
+			eb.Entries[i].Term = term
+			eb.Entries[i].Index = idx + uint64(i)
+		}
+	}
+}

--- a/tools/logdump/proto/decode.go
+++ b/tools/logdump/proto/decode.go
@@ -66,17 +66,33 @@ type DecodedCmd struct {
 }
 
 type decodeConfig struct {
-	walkEntryCmd bool
+	decodeEntryCmd bool
+
+	cmdDecoder func([]byte) (msg ProtoMessage, sum string, err error)
 }
 
 // DecodeOption configures DecodeCmd behavior.
 type DecodeOption func(*decodeConfig)
 
+// WithEntryHeaderDecode enables decoding of entry headers.
+func WithEntryHeaderDecode() DecodeOption {
+	return func(c *decodeConfig) {
+		// stub
+	}
+}
+
 // WithEntryCmdDecode enables protobuf payload walking on EncodedEntry
 // and raw Cmd fields via WalkProtoMessage.
 func WithEntryCmdDecode() DecodeOption {
 	return func(c *decodeConfig) {
-		c.walkEntryCmd = true
+		c.decodeEntryCmd = true
+	}
+}
+
+// WithCmdDecoder sets the function to decode a cmd field.
+func WithCmdDecoder(f func([]byte) (ProtoMessage, string, error)) DecodeOption {
+	return func(c *decodeConfig) {
+		c.cmdDecoder = f
 	}
 }
 
@@ -221,12 +237,19 @@ func decodeEncodedEntry(cmd []byte, cfg *decodeConfig) (*DecodedCmd, error) {
 
 	switch comp {
 	case eeNoCompression:
+		var summary string
 		detail.Compression = "none"
 		payload := cmd[1:]
 		detail.Size = len(payload)
-		if cfg.walkEntryCmd {
-			if pm, err := WalkProtoMessage(payload); err == nil {
-				detail.ProtoMessage = pm
+		if cfg.decodeEntryCmd {
+			var err error
+			if cfg.cmdDecoder != nil {
+				detail.ProtoMessage, summary, err = cfg.cmdDecoder(payload)
+			} else {
+				detail.ProtoMessage, err = WalkProtoMessage(payload)
+			}
+			if err != nil {
+				return nil, err
 			}
 		}
 		if detail.ProtoMessage == nil {
@@ -235,7 +258,9 @@ func decodeEncodedEntry(cmd []byte, cfg *decodeConfig) (*DecodedCmd, error) {
 				detail.PayloadText = string(payload)
 			}
 		}
-		summary := fmt.Sprintf("[v0 uncompressed] %d B", detail.Size)
+		if summary == "" {
+			summary = fmt.Sprintf("[v0 uncompressed] %d B", detail.Size)
+		}
 		return &DecodedCmd{
 			Kind:         KindEncodedEntry,
 			Summary:      summary,
@@ -243,29 +268,38 @@ func decodeEncodedEntry(cmd []byte, cfg *decodeConfig) (*DecodedCmd, error) {
 		}, nil
 
 	case eeSnappy:
+		var summary string
 		detail.Compression = "snappy"
 		decodedLen, err := snappy.DecodedLen(cmd[1:])
 		if err != nil {
 			return nil, fmt.Errorf("snappy decoded length: %w", err)
 		}
 		dst := make([]byte, decodedLen)
-		result, err := snappy.Decode(dst, cmd[1:])
+		payload, err := snappy.Decode(dst, cmd[1:])
 		if err != nil {
 			return nil, fmt.Errorf("snappy decode: %w", err)
 		}
-		detail.Size = len(result)
-		if cfg.walkEntryCmd {
-			if pm, err := WalkProtoMessage(result); err == nil {
-				detail.ProtoMessage = pm
+		detail.Size = len(payload)
+		if cfg.decodeEntryCmd {
+			var err error
+			if cfg.cmdDecoder != nil {
+				detail.ProtoMessage, summary, err = cfg.cmdDecoder(payload)
+			} else {
+				detail.ProtoMessage, err = WalkProtoMessage(payload)
+			}
+			if err != nil {
+				return nil, err
 			}
 		}
 		if detail.ProtoMessage == nil {
-			detail.PayloadHex = hex.EncodeToString(result)
-			if isPrintable(string(result)) {
-				detail.PayloadText = string(result)
+			detail.PayloadHex = hex.EncodeToString(payload)
+			if isPrintable(string(payload)) {
+				detail.PayloadText = string(payload)
 			}
 		}
-		summary := fmt.Sprintf("[v0 snappy] %d B", detail.Size)
+		if summary == "" {
+			summary = fmt.Sprintf("[v0 snappy] %d B", detail.Size)
+		}
 		return &DecodedCmd{
 			Kind:         KindEncodedEntry,
 			Summary:      summary,
@@ -286,7 +320,7 @@ func decodeRaw(cmd []byte, cfg *decodeConfig) *DecodedCmd {
 		Summary: summary,
 		RawHex:  hex.EncodeToString(cmd),
 	}
-	if cfg.walkEntryCmd && len(cmd) > 0 {
+	if cfg.decodeEntryCmd && len(cmd) > 0 {
 		if pm, err := WalkProtoMessage(cmd); err == nil {
 			d.ProtoMessage = pm
 		}

--- a/tools/logdump/proto/decode_test.go
+++ b/tools/logdump/proto/decode_test.go
@@ -1,0 +1,368 @@
+package proto
+
+import (
+	"encoding/hex"
+	"math"
+	"testing"
+
+	"github.com/golang/snappy"
+
+	pb "github.com/lni/dragonboat/v3/raftpb"
+)
+
+func TestDecodeCmd_SessionEntries(t *testing.T) {
+	tests := []struct {
+		name     string
+		entry    pb.Entry
+		wantKind CmdKind
+		wantSum  string
+	}{
+		{
+			name:     "new session",
+			entry:    pb.Entry{Type: pb.ApplicationEntry, ClientID: 100, SeriesID: math.MaxUint64 - 1},
+			wantKind: KindSession,
+			wantSum:  "(new session)",
+		},
+		{
+			name:     "end session",
+			entry:    pb.Entry{Type: pb.ApplicationEntry, ClientID: 100, SeriesID: math.MaxUint64},
+			wantKind: KindSession,
+			wantSum:  "(end session)",
+		},
+		{
+			name:     "no-op session",
+			entry:    pb.Entry{Type: pb.ApplicationEntry, ClientID: 100, SeriesID: 0, Cmd: nil},
+			wantKind: KindSession,
+			wantSum:  "(no-op)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, err := DecodeCmd(tt.entry)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if d.Kind != tt.wantKind {
+				t.Errorf("Kind = %v, want %v", d.Kind, tt.wantKind)
+			}
+			if d.Summary != tt.wantSum {
+				t.Errorf("Summary = %q, want %q", d.Summary, tt.wantSum)
+			}
+		})
+	}
+}
+
+func TestDecodeCmd_EmptyEntry(t *testing.T) {
+	d, err := DecodeCmd(pb.Entry{Type: pb.MetadataEntry})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d.Kind != KindEmpty {
+		t.Errorf("Kind = %v, want KindEmpty", d.Kind)
+	}
+	if d.Summary != "(empty)" {
+		t.Errorf("Summary = %q, want (empty)", d.Summary)
+	}
+}
+
+func TestDecodeCmd_ConfigChange(t *testing.T) {
+	cc := pb.ConfigChange{
+		ConfigChangeId: 42,
+		Type:           pb.AddNode,
+		NodeID:         3,
+		Address:        "node3:8080",
+		Initialize:     true,
+	}
+	cmd, err := cc.Marshal()
+	if err != nil {
+		t.Fatalf("marshal ConfigChange: %v", err)
+	}
+
+	d, err := DecodeCmd(pb.Entry{Type: pb.ConfigChangeEntry, Cmd: cmd})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d.Kind != KindConfigChange {
+		t.Errorf("Kind = %v, want KindConfigChange", d.Kind)
+	}
+	if d.ConfigChange == nil {
+		t.Fatal("ConfigChange is nil")
+	}
+	if d.ConfigChange.ConfigChangeID != 42 {
+		t.Errorf("ConfigChangeID = %d, want 42", d.ConfigChange.ConfigChangeID)
+	}
+	if d.ConfigChange.Type != "AddNode" {
+		t.Errorf("Type = %q, want AddNode", d.ConfigChange.Type)
+	}
+	if d.ConfigChange.NodeID != 3 {
+		t.Errorf("NodeID = %d, want 3", d.ConfigChange.NodeID)
+	}
+	if d.ConfigChange.Address != "node3:8080" {
+		t.Errorf("Address = %q, want node3:8080", d.ConfigChange.Address)
+	}
+	if !d.ConfigChange.Initialize {
+		t.Error("Initialize should be true")
+	}
+}
+
+func TestDecodeCmd_ConfigChangeTypes(t *testing.T) {
+	types := []struct {
+		ct   pb.ConfigChangeType
+		name string
+	}{
+		{pb.AddNode, "AddNode"},
+		{pb.RemoveNode, "RemoveNode"},
+		{pb.AddObserver, "AddObserver"},
+		{pb.AddWitness, "AddWitness"},
+	}
+	for _, tt := range types {
+		t.Run(tt.name, func(t *testing.T) {
+			cc := pb.ConfigChange{Type: tt.ct, NodeID: 1}
+			cmd, err := cc.Marshal()
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			d, err := DecodeCmd(pb.Entry{Type: pb.ConfigChangeEntry, Cmd: cmd})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if d.ConfigChange.Type != tt.name {
+				t.Errorf("Type = %q, want %q", d.ConfigChange.Type, tt.name)
+			}
+		})
+	}
+}
+
+func TestDecodeCmd_EncodedEntry_NoCompression(t *testing.T) {
+	payload := []byte("hello encoded")
+	cmd := make([]byte, 1+len(payload))
+	cmd[0] = 0 // V0, no compression, no session
+	copy(cmd[1:], payload)
+
+	d, err := DecodeCmd(pb.Entry{Type: pb.EncodedEntry, Cmd: cmd})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d.Kind != KindEncodedEntry {
+		t.Errorf("Kind = %v, want KindEncodedEntry", d.Kind)
+	}
+	if d.EncodedEntry.Compression != "none" {
+		t.Errorf("Compression = %q, want none", d.EncodedEntry.Compression)
+	}
+	if d.EncodedEntry.Size != len(payload) {
+		t.Errorf("Size = %d, want %d", d.EncodedEntry.Size, len(payload))
+	}
+	if d.EncodedEntry.PayloadText != string(payload) {
+		t.Errorf("PayloadText = %q, want %q", d.EncodedEntry.PayloadText, string(payload))
+	}
+}
+
+func TestDecodeCmd_EncodedEntry_Snappy(t *testing.T) {
+	payload := []byte("compress me please compress me please")
+	encoded := snappy.Encode(nil, payload)
+	cmd := make([]byte, 1+len(encoded))
+	cmd[0] = eeV0 | eeSnappy // V0, snappy compression
+	copy(cmd[1:], encoded)
+
+	d, err := DecodeCmd(pb.Entry{Type: pb.EncodedEntry, Cmd: cmd})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d.Kind != KindEncodedEntry {
+		t.Errorf("Kind = %v, want KindEncodedEntry", d.Kind)
+	}
+	if d.EncodedEntry.Compression != "snappy" {
+		t.Errorf("Compression = %q, want snappy", d.EncodedEntry.Compression)
+	}
+	if d.EncodedEntry.Size != len(payload) {
+		t.Errorf("Size = %d, want %d", d.EncodedEntry.Size, len(payload))
+	}
+	if d.EncodedEntry.PayloadText != string(payload) {
+		t.Errorf("PayloadText = %q, want %q", d.EncodedEntry.PayloadText, string(payload))
+	}
+}
+
+func TestDecodeCmd_Raw_Printable(t *testing.T) {
+	cmd := []byte("hello world")
+	d, err := DecodeCmd(pb.Entry{Type: pb.ApplicationEntry, Cmd: cmd})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d.Kind != KindRaw {
+		t.Errorf("Kind = %v, want KindRaw", d.Kind)
+	}
+	if d.Summary != "hello world" {
+		t.Errorf("Summary = %q, want hello world", d.Summary)
+	}
+	if d.RawHex != hex.EncodeToString(cmd) {
+		t.Errorf("RawHex mismatch")
+	}
+}
+
+func TestDecodeCmd_Raw_Binary(t *testing.T) {
+	cmd := []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01, 0x02, 0x03}
+	d, err := DecodeCmd(pb.Entry{Type: pb.ApplicationEntry, Cmd: cmd})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d.Kind != KindRaw {
+		t.Errorf("Kind = %v, want KindRaw", d.Kind)
+	}
+	if d.Summary != "deadbeef0001... (8 B)" {
+		t.Errorf("Summary = %q, want deadbeef0001... (8 B)", d.Summary)
+	}
+}
+
+func TestDecodeCmd_Raw_MetadataEntry(t *testing.T) {
+	cmd := []byte{0x01, 0x02}
+	d, err := DecodeCmd(pb.Entry{Type: pb.MetadataEntry, Cmd: cmd})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d.Kind != KindRaw {
+		t.Errorf("Kind = %v, want KindRaw", d.Kind)
+	}
+	if d.RawHex != "0102" {
+		t.Errorf("RawHex = %q, want 0102", d.RawHex)
+	}
+}
+
+func TestDecodeCmd_Errors(t *testing.T) {
+	t.Run("malformed config change", func(t *testing.T) {
+		_, err := DecodeCmd(pb.Entry{Type: pb.ConfigChangeEntry, Cmd: []byte{0xFF, 0xFF, 0xFF}})
+		if err == nil {
+			t.Error("expected error for malformed ConfigChange")
+		}
+	})
+
+	t.Run("truncated encoded entry", func(t *testing.T) {
+		_, err := DecodeCmd(pb.Entry{Type: pb.EncodedEntry, Cmd: nil})
+		if err == nil {
+			t.Error("expected error for nil Cmd on EncodedEntry")
+		}
+	})
+
+	t.Run("bad snappy data", func(t *testing.T) {
+		cmd := make([]byte, 5)
+		cmd[0] = eeV0 | eeSnappy
+		cmd[1] = 0xFF // not valid snappy
+		_, err := DecodeCmd(pb.Entry{Type: pb.EncodedEntry, Cmd: cmd})
+		if err == nil {
+			t.Error("expected error for bad snappy data")
+		}
+	})
+}
+
+func TestDecodeCmd_MarshalJSON_RoundTrip(t *testing.T) {
+	cc := pb.ConfigChange{Type: pb.RemoveNode, NodeID: 5}
+	cmd, _ := cc.Marshal()
+	d, _ := DecodeCmd(pb.Entry{Type: pb.ConfigChangeEntry, Cmd: cmd})
+
+	b, err := d.Kind.MarshalJSON()
+	if err != nil {
+		t.Fatalf("MarshalJSON: %v", err)
+	}
+	if string(b) != `"config_change"` {
+		t.Errorf("Kind JSON = %s, want \"config_change\"", b)
+	}
+}
+
+func TestDecodeValue_PlainEntry(t *testing.T) {
+	e := pb.Entry{
+		Term:  7,
+		Index: 100,
+		Type:  pb.ApplicationEntry,
+		Cmd:   []byte("test"),
+	}
+	raw, err := e.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	entries, err := DecodeValue(raw)
+	if err != nil {
+		t.Fatalf("DecodeValue: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+	if entries[0].Term != 7 || entries[0].Index != 100 {
+		t.Errorf("Term/Index mismatch: %d/%d", entries[0].Term, entries[0].Index)
+	}
+	if string(entries[0].Cmd) != "test" {
+		t.Errorf("Cmd = %q, want test", entries[0].Cmd)
+	}
+}
+
+func TestDecodeValue_BatchEntry(t *testing.T) {
+	eb := pb.EntryBatch{
+		Entries: []pb.Entry{
+			{Term: 5, Index: 10, Type: pb.ApplicationEntry, Cmd: []byte("a")},
+			{Term: 5, Index: 11, Type: pb.ApplicationEntry, Cmd: []byte("b")},
+			{Term: 5, Index: 12, Type: pb.ApplicationEntry, Cmd: []byte("c")},
+		},
+	}
+	raw, err := eb.Marshal()
+	if err != nil {
+		t.Fatalf("marshal batch: %v", err)
+	}
+
+	entries, err := DecodeValue(raw)
+	if err != nil {
+		t.Fatalf("DecodeValue: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("got %d entries, want 3", len(entries))
+	}
+	for i, e := range entries {
+		wantIdx := uint64(10 + i)
+		if e.Index != wantIdx {
+			t.Errorf("entry %d: Index = %d, want %d", i, e.Index, wantIdx)
+		}
+		if e.Term != 5 {
+			t.Errorf("entry %d: Term = %d, want 5", i, e.Term)
+		}
+	}
+}
+
+func TestDecodeValue_BatchWithCompactedFields(t *testing.T) {
+	eb := pb.EntryBatch{
+		Entries: []pb.Entry{
+			{Term: 5, Index: 10, Type: pb.ApplicationEntry, Cmd: []byte("a")},
+			{Term: 0, Index: 0, Type: pb.ApplicationEntry, Cmd: []byte("b")},
+			{Term: 0, Index: 0, Type: pb.ApplicationEntry, Cmd: []byte("c")},
+		},
+	}
+	raw, err := eb.Marshal()
+	if err != nil {
+		t.Fatalf("marshal batch: %v", err)
+	}
+
+	entries, err := DecodeValue(raw)
+	if err != nil {
+		t.Fatalf("DecodeValue: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("got %d entries, want 3", len(entries))
+	}
+	for i, e := range entries {
+		wantIdx := uint64(10 + i)
+		if e.Index != wantIdx {
+			t.Errorf("entry %d: Index = %d, want %d (fields should be restored)", i, e.Index, wantIdx)
+		}
+		if e.Term != 5 {
+			t.Errorf("entry %d: Term = %d, want 5 (fields should be restored)", i, e.Term)
+		}
+	}
+}
+
+func TestDecodeValue_Error_Empty(t *testing.T) {
+	_, err := DecodeValue(nil)
+	if err == nil {
+		t.Error("expected error for nil input")
+	}
+	_, err = DecodeValue([]byte{})
+	if err == nil {
+		t.Error("expected error for empty input")
+	}
+}

--- a/tools/logdump/proto/proto.go
+++ b/tools/logdump/proto/proto.go
@@ -1,0 +1,255 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proto
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"unicode/utf8"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+type ProtoField struct {
+	ID       int32          `json:"id"`
+	WireType protowire.Type `json:"-"`
+
+	Type  string      `json:"type_url,omitempty"`
+	Value interface{} `json:"value,omitempty"`
+}
+
+// ProtoMessage represents a decoded protobuf message.
+type ProtoMessage []ProtoField
+
+// Type registry for protojson decode of known Any types.
+var (
+	registryMu    sync.RWMutex
+	registryTypes = map[string]proto.Message{}
+)
+
+func init() {
+	var file_google_protobuf_wrappers_proto_goTypes = []interface{}{
+		(*wrapperspb.DoubleValue)(nil), // 0: google.protobuf.DoubleValue
+		(*wrapperspb.FloatValue)(nil),  // 1: google.protobuf.FloatValue
+		(*wrapperspb.Int64Value)(nil),  // 2: google.protobuf.Int64Value
+		(*wrapperspb.UInt64Value)(nil), // 3: google.protobuf.UInt64Value
+		(*wrapperspb.Int32Value)(nil),  // 4: google.protobuf.Int32Value
+		(*wrapperspb.UInt32Value)(nil), // 5: google.protobuf.UInt32Value
+		(*wrapperspb.BoolValue)(nil),   // 6: google.protobuf.BoolValue
+		(*wrapperspb.StringValue)(nil), // 7: google.protobuf.StringValue
+		(*wrapperspb.BytesValue)(nil),  // 8: google.protobuf.BytesValue
+	}
+
+	for _, m := range file_google_protobuf_wrappers_proto_goTypes {
+		if m, ok := m.(proto.Message); ok {
+			RegisterProtoType(m)
+		}
+	}
+}
+
+// RegisterProtoType registers a proto.Message for protojson decode when
+// a google.protobuf.Any with a matching type_url is encountered.
+func RegisterProtoType(m proto.Message) {
+	if m == nil {
+		panic("RegisterProtoType: nil message")
+	}
+	name := string(m.ProtoReflect().Descriptor().FullName())
+	typeURL := "type.googleapis.com/" + name
+	registryMu.Lock()
+	registryTypes[typeURL] = m
+	registryMu.Unlock()
+}
+
+func lookupRegisteredType(typeURL string) (proto.Message, bool) {
+	registryMu.RLock()
+	m, ok := registryTypes[typeURL]
+	registryMu.RUnlock()
+	return m, ok
+}
+
+// safeIntValue returns the integer as a float64, or as a string if the value
+// exceeds 2^53 where float64 precision loss would occur.
+func safeIntValue(v uint64) interface{} {
+	if v > 9007199254740992 {
+		return fmt.Sprintf("%d", v)
+	}
+	return float64(v)
+}
+
+// bytesValue returns a human-readable representation of raw bytes.
+// Printable UTF-8 strings are returned as-is; otherwise hex-encoded.
+func bytesValue(raw []byte) interface{} {
+	if utf8.Valid(raw) && isPrintable(string(raw)) {
+		return string(raw)
+	}
+
+	return raw
+}
+
+// isPlausibleMessage heuristically checks whether raw bytes might be
+// a protobuf message by peeking at the first byte's wire type.
+func isPlausibleMessage(data []byte) bool {
+	if len(data) == 0 {
+		return false
+	}
+	wt := data[0] & 0x7
+	return wt <= 5
+}
+
+const anyTypePrefix = "type.googleapis.com/"
+
+// isAnyShape detects a google.protobuf.Any wrapper by its 2-field shape:
+// field 1 = type_url (string), field 2 = value (bytes).
+func isAnyShape(fields []ProtoField) (typeURL string, ok bool) {
+	if len(fields) < 1 {
+		return "", false
+	}
+	f1 := fields[0]
+	if f1.ID != 1 || f1.WireType != protowire.BytesType {
+		return "", false
+	}
+	s, isStr := f1.Value.(string)
+	if !isStr {
+		return "", false
+	}
+	if len(s) <= len(anyTypePrefix) || s[:len(anyTypePrefix)] != anyTypePrefix {
+		return "", false
+	}
+	if len(fields) > 1 {
+		f2 := fields[1]
+		if f2.ID != 2 || f2.WireType != protowire.BytesType {
+			return "", false
+		}
+	}
+	return s, true
+}
+
+const maxWalkDepth = 64
+
+// WalkProtoMessage parses raw protobuf wire-format bytes into a ProtoMessage.
+// It auto-detects google.protobuf.Any wrappers and transparently unwraps them.
+// Nested message depth is limited to 64.
+func WalkProtoMessage(data []byte) (ProtoMessage, error) {
+	if len(data) == 0 {
+		return ProtoMessage{}, nil
+	}
+
+	fields, n, err := walkFields(data, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	if n != len(data) {
+		return nil, fmt.Errorf("trailing bytes after protobuf message: %d of %d consumed", n, len(data))
+	}
+
+	return fields, nil
+}
+
+func walkFields(data []byte, depth int) ([]ProtoField, int, error) {
+	start := len(data)
+
+	if depth >= maxWalkDepth {
+		return nil, 0, fmt.Errorf("max protobuf nesting depth %d exceeded", maxWalkDepth)
+	}
+
+	var fields []ProtoField
+	for len(data) > 0 {
+		tag, wt, n := protowire.ConsumeTag(data)
+		if n < 0 {
+			return fields, 0, fmt.Errorf("truncated protobuf tag")
+		}
+		data = data[n:]
+
+		field := ProtoField{ID: int32(tag), WireType: wt}
+
+		switch wt {
+		case protowire.VarintType:
+			v, n := protowire.ConsumeVarint(data)
+			if n < 0 {
+				return fields, start - len(data), fmt.Errorf("truncated varint for field %d", tag)
+			}
+			field.Value = safeIntValue(v)
+			data = data[n:]
+		case protowire.Fixed32Type:
+			v, n := protowire.ConsumeFixed32(data)
+			if n < 0 {
+				return fields, start - len(data), fmt.Errorf("truncated fixed32 for field %d", tag)
+			}
+			field.Value = safeIntValue(uint64(v))
+			data = data[n:]
+		case protowire.Fixed64Type:
+			v, n := protowire.ConsumeFixed64(data)
+			if n < 0 {
+				return fields, start - len(data), fmt.Errorf("truncated fixed64 for field %d", tag)
+			}
+			field.Value = safeIntValue(v)
+			data = data[n:]
+		case protowire.BytesType:
+			raw, n := protowire.ConsumeBytes(data)
+			if n < 0 {
+				return fields, start - len(data), fmt.Errorf("truncated length-delimited for field %d", tag)
+			}
+			field.Value = bytesValue(raw)
+			data = data[n:]
+
+			if isPlausibleMessage(raw) {
+				children, _, err := walkFields(raw, depth+1)
+				if err == nil {
+					if typeURL, ok := isAnyShape(children); ok {
+						field.Type = typeURL
+						field.Value = nil
+						if len(children) > 1 {
+							field.Value = children[1].Value
+						}
+						if regMsg, registered := lookupRegisteredType(typeURL); registered {
+							msg := regMsg.ProtoReflect().New().Interface()
+							if err := proto.Unmarshal(raw, msg); err != nil {
+								return fields, start - len(data), fmt.Errorf("failed to unmarshal Any message for field %d: %w", tag, err)
+							}
+							// convert to some universal JSON representation using protojson.
+							mo := protojson.MarshalOptions{Multiline: false, EmitUnpopulated: true}
+							b, err := mo.Marshal(msg)
+							if err != nil {
+								return fields, start - len(data), fmt.Errorf("failed to marshal Any message to JSON for field %d: %w", tag, err)
+							}
+							field.Value = json.RawMessage(b)
+						}
+					} else if len(children) > 0 {
+						field.Value = ProtoMessage(children)
+					}
+				}
+			}
+		case protowire.StartGroupType:
+			children, n, err := walkFields(data, depth+1)
+			if err != nil {
+				return fields, start - len(data), fmt.Errorf("failed to walk group for field %d: %w", tag, err)
+			}
+			data = data[n:]
+			if len(children) > 0 {
+				field.Value = ProtoMessage(children)
+			}
+		case protowire.EndGroupType:
+			consumed := start - len(data)
+			return fields, consumed, nil
+		}
+
+		fields = append(fields, field)
+	}
+
+	return fields, start - len(data), nil
+}

--- a/tools/logdump/proto/proto_test.go
+++ b/tools/logdump/proto/proto_test.go
@@ -808,4 +808,4 @@ func TestWalkProtoMessage_MultipleFields(t *testing.T) {
 	if _, ok := pm[2].Value.(ProtoMessage); !ok {
 		t.Errorf("field 2: Value type = %T, want ProtoMessage (printable bytes parsed as nested)", pm[2].Value)
 	}
-	}
+}

--- a/tools/logdump/proto/proto_test.go
+++ b/tools/logdump/proto/proto_test.go
@@ -1,0 +1,811 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proto
+
+import (
+	"encoding/json"
+	"math"
+	"strings"
+	"sync"
+	"testing"
+
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// ---------------------------------------------------------------------------
+// SafeIntValue
+// ---------------------------------------------------------------------------
+
+func TestSafeIntValue_Boundary(t *testing.T) {
+	tests := []struct {
+		name string
+		v    uint64
+		want interface{}
+	}{
+		{"zero", 0, float64(0)},
+		{"one", 1, float64(1)},
+		{"small", 42, float64(42)},
+		{"exact_2pow53", 9007199254740992, float64(9007199254740992)},
+		{"above_2pow53", 9007199254740993, "9007199254740993"},
+		{"max_uint64", math.MaxUint64, "18446744073709551615"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := safeIntValue(tt.v)
+			if got != tt.want {
+				t.Errorf("safeIntValue(%d) = %#v, want %#v", tt.v, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IsPlausibleMessage
+// ---------------------------------------------------------------------------
+
+func TestIsPlausibleMessage_Valid(t *testing.T) {
+	valid := [][]byte{
+		{0x00},       // wt=0 (varint)
+		{0x08},       // wt=0 (varint), fn=1
+		{0x09},       // wt=1 (fixed64), fn=1
+		{0x0a},       // wt=2 (bytes), fn=1
+		{0x0b},       // wt=3 (start_group), fn=1
+		{0x0c},       // wt=4 (end_group), fn=1
+		{0x0d},       // wt=5 (fixed32), fn=1
+		{0x12},       // wt=2 (bytes), fn=2
+		{0x1d},       // wt=5 (fixed32), fn=3
+		{0x22},       // wt=2 (bytes), fn=4
+		{0x2d},       // wt=5 (fixed32), fn=5
+		{0x08, 0x00}, // valid varint field with value 0
+	}
+	for _, b := range valid {
+		if !isPlausibleMessage(b) {
+			t.Errorf("isPlausibleMessage(%x) = false, want true", b)
+		}
+	}
+}
+
+func TestIsPlausibleMessage_Invalid(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{"empty", nil},
+		{"empty_slice", []byte{}},
+		{"wt6", []byte{0x06}},              // illegal wire type 6
+		{"wt7", []byte{0x07}},              // illegal wire type 7
+		{"fn1_wt6", []byte{0x0e}},          // fn=1, wt=6
+		{"fn1_wt7", []byte{0x0f}},          // fn=1, wt=7
+		{"fn2_wt6", []byte{0x16}},          // fn=2, wt=6
+		{"high_wt6", []byte{0x3e}},         // fn=7, wt=6
+		{"highest_reserved", []byte{0x3f}}, // fn=7, wt=7
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if isPlausibleMessage(tt.data) {
+				t.Errorf("isPlausibleMessage(%x) = true, want false", tt.data)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IsAnyShape
+// ---------------------------------------------------------------------------
+
+func TestIsAnyShape_Positive(t *testing.T) {
+	fields := []ProtoField{
+		{ID: 1, WireType: protowire.BytesType, Value: "type.googleapis.com/google.protobuf.UInt64Value"},
+		{ID: 2, WireType: protowire.BytesType},
+	}
+	typeURL, ok := isAnyShape(fields)
+	if !ok {
+		t.Fatal("isAnyShape returned false for valid Any shape")
+	}
+	if typeURL != "type.googleapis.com/google.protobuf.UInt64Value" {
+		t.Errorf("typeURL = %q, want %q", typeURL, "type.googleapis.com/google.protobuf.UInt64Value")
+	}
+}
+
+func TestIsAnyShape_Negative(t *testing.T) {
+	tests := []struct {
+		name   string
+		fields []ProtoField
+	}{
+		{
+			"wrong_field_numbers_1_and_3",
+			[]ProtoField{
+				{ID: 1, WireType: protowire.BytesType, Value: "type.googleapis.com/SomeType"},
+				{ID: 3, WireType: protowire.BytesType},
+			},
+		},
+		{
+			"wrong_field_numbers_2_and_3",
+			[]ProtoField{
+				{ID: 2, WireType: protowire.BytesType, Value: "type.googleapis.com/SomeType"},
+				{ID: 3, WireType: protowire.BytesType},
+			},
+		},
+		{
+			"field1_not_string",
+			[]ProtoField{
+				{ID: 1, WireType: protowire.VarintType, Value: float64(42)},
+				{ID: 2, WireType: protowire.BytesType},
+			},
+		},
+		{
+			"field1_wrong_prefix",
+			[]ProtoField{
+				{ID: 1, WireType: protowire.BytesType, Value: "x/type.googleapis.com/Foo"},
+				{ID: 2, WireType: protowire.BytesType},
+			},
+		},
+		{
+			"field1_short_prefix",
+			[]ProtoField{
+				{ID: 1, WireType: protowire.BytesType, Value: "type.googleapis.com/"},
+				{ID: 2, WireType: protowire.BytesType},
+			},
+		},
+		{
+			"field2_wrong_wire_type",
+			[]ProtoField{
+				{ID: 1, WireType: protowire.BytesType, Value: "type.googleapis.com/SomeType"},
+				{ID: 2, WireType: protowire.VarintType, Value: float64(42)},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ok := isAnyShape(tt.fields)
+			if ok {
+				t.Errorf("isAnyShape returned true, want false")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WalkProtoMessage  --  Field values
+// ---------------------------------------------------------------------------
+
+func TestWalkProtoMessage_VarintValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		val     uint64
+		wantVal interface{}
+	}{
+		{"zero", 0, float64(0)},
+		{"one", 1, float64(1)},
+		{"large_2pow53", 9007199254740992, float64(9007199254740992)},
+		{"above_float_safe", 9007199254740993, "9007199254740993"},
+		{"max_uint64", math.MaxUint64, "18446744073709551615"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := protowire.AppendTag(nil, 1, protowire.VarintType)
+			b = protowire.AppendVarint(b, tt.val)
+
+			pm, err := WalkProtoMessage(b)
+			if err != nil {
+				t.Fatalf("WalkProtoMessage: %v", err)
+			}
+			if len(pm) != 1 {
+				t.Fatalf("got %d fields, want 1", len(pm))
+			}
+			f := pm[0]
+			if f.ID != 1 {
+				t.Errorf("ID = %d, want 1", f.ID)
+			}
+			if f.WireType != protowire.VarintType {
+				t.Errorf("WireType = %q, want varint", f.WireType)
+			}
+			if f.Value != tt.wantVal {
+				t.Errorf("Value = %#v (%T), want %#v (%T)", f.Value, f.Value, tt.wantVal, tt.wantVal)
+			}
+		})
+	}
+}
+
+func TestWalkProtoMessage_Fixed32(t *testing.T) {
+	const val uint32 = 0xDEADBEEF
+	b := protowire.AppendTag(nil, 2, protowire.Fixed32Type)
+	b = protowire.AppendFixed32(b, val)
+
+	pm, err := WalkProtoMessage(b)
+	if err != nil {
+		t.Fatalf("WalkProtoMessage: %v", err)
+	}
+	if len(pm) != 1 {
+		t.Fatalf("got %d fields, want 1", len(pm))
+	}
+	f := pm[0]
+	if f.ID != 2 {
+		t.Errorf("ID = %d, want 2", f.ID)
+	}
+	if f.WireType != protowire.Fixed32Type {
+		t.Errorf("WireType = %q, want fixed32", f.WireType)
+	}
+	if f.Value != float64(val) {
+		t.Errorf("Value = %#v, want %#v", f.Value, float64(val))
+	}
+}
+
+func TestWalkProtoMessage_Fixed64(t *testing.T) {
+	const val uint64 = 0xABCD
+	b := protowire.AppendTag(nil, 3, protowire.Fixed64Type)
+	b = protowire.AppendFixed64(b, val)
+
+	pm, err := WalkProtoMessage(b)
+	if err != nil {
+		t.Fatalf("WalkProtoMessage: %v", err)
+	}
+	if len(pm) != 1 {
+		t.Fatalf("got %d fields, want 1", len(pm))
+	}
+	f := pm[0]
+	if f.ID != 3 {
+		t.Errorf("ID = %d, want 3", f.ID)
+	}
+	if f.WireType != protowire.Fixed64Type {
+		t.Errorf("WireType = %q, want fixed64", f.WireType)
+	}
+	if f.Value != float64(val) {
+		t.Errorf("Value = %#v (%T), want %#v", f.Value, f.Value, float64(val))
+	}
+}
+
+func TestWalkProtoMessage_Fixed64HighValue(t *testing.T) {
+	const val uint64 = 9007199254740993 // > 2^53
+	b := protowire.AppendTag(nil, 1, protowire.Fixed64Type)
+	b = protowire.AppendFixed64(b, val)
+
+	pm, err := WalkProtoMessage(b)
+	if err != nil {
+		t.Fatalf("WalkProtoMessage: %v", err)
+	}
+	f := pm[0]
+	if f.Value != "9007199254740993" {
+		t.Errorf("Value = %#v (%T), want string \"9007199254740993\"", f.Value, f.Value)
+	}
+}
+
+func TestWalkProtoMessage_StringField(t *testing.T) {
+	b := protowire.AppendTag(nil, 1, protowire.BytesType)
+	b = protowire.AppendBytes(b, []byte("hello world"))
+
+	pm, err := WalkProtoMessage(b)
+	if err != nil {
+		t.Fatalf("WalkProtoMessage: %v", err)
+	}
+	if len(pm) != 1 {
+		t.Fatalf("got %d fields, want 1", len(pm))
+	}
+	f := pm[0]
+	if _, ok := f.Value.(ProtoMessage); !ok {
+		t.Errorf("Value type = %T, want ProtoMessage (printable bytes parsed as nested)", f.Value)
+	}
+}
+
+func TestWalkProtoMessage_BytesField_NonPrintable(t *testing.T) {
+	b := protowire.AppendTag(nil, 1, protowire.BytesType)
+	b = protowire.AppendBytes(b, []byte{0x00, 0xFF, 0xDE, 0xAD})
+
+	pm, err := WalkProtoMessage(b)
+	if err != nil {
+		t.Fatalf("WalkProtoMessage: %v", err)
+	}
+	f := pm[0]
+	got, ok := f.Value.([]byte)
+	if !ok {
+		t.Fatalf("Value type = %T, want []byte", f.Value)
+	}
+	if len(got) != 4 || got[0] != 0x00 || got[1] != 0xFF || got[2] != 0xDE || got[3] != 0xAD {
+		t.Errorf("Value = %#v, want []byte{0x00, 0xFF, 0xDE, 0xAD}", got)
+	}
+}
+
+func TestWalkProtoMessage_BytesField_NonUTF8(t *testing.T) {
+	// A byte sequence that is not valid UTF-8
+	b := protowire.AppendTag(nil, 1, protowire.BytesType)
+	b = protowire.AppendBytes(b, []byte{0xFF, 0xFE, 0xFD})
+
+	pm, err := WalkProtoMessage(b)
+	if err != nil {
+		t.Fatalf("WalkProtoMessage: %v", err)
+	}
+	f := pm[0]
+	got, ok := f.Value.([]byte)
+	if !ok {
+		t.Fatalf("Value type = %T, want []byte", f.Value)
+	}
+	if len(got) != 3 || got[0] != 0xFF || got[1] != 0xFE || got[2] != 0xFD {
+		t.Errorf("Value = %#v, want []byte{0xFF, 0xFE, 0xFD}", got)
+	}
+}
+
+func TestWalkProtoMessage_EmptyBytesField(t *testing.T) {
+	b := protowire.AppendTag(nil, 1, protowire.BytesType)
+	b = protowire.AppendBytes(b, nil)
+
+	pm, err := WalkProtoMessage(b)
+	if err != nil {
+		t.Fatalf("WalkProtoMessage: %v", err)
+	}
+	f := pm[0]
+	if f.Value != "" {
+		t.Errorf("Value = %#v, want empty string", f.Value)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WalkProtoMessage  --  Nested messages
+// ---------------------------------------------------------------------------
+
+func TestWalkProtoMessage_NestedMessages(t *testing.T) {
+	inner := protowire.AppendTag(nil, 1, protowire.VarintType)
+	inner = protowire.AppendVarint(inner, 100)
+
+	outer := protowire.AppendTag(nil, 2, protowire.BytesType)
+	outer = protowire.AppendBytes(outer, inner)
+
+	pm, err := WalkProtoMessage(outer)
+	if err != nil {
+		t.Fatalf("WalkProtoMessage: %v", err)
+	}
+	if len(pm) != 1 {
+		t.Fatalf("got %d fields, want 1", len(pm))
+	}
+	f := pm[0]
+	if f.ID != 2 {
+		t.Errorf("ID = %d, want 2", f.ID)
+	}
+	if f.WireType != protowire.BytesType {
+		t.Errorf("WireType = %q, want length_delimited", f.WireType)
+	}
+	if len(f.Value.(ProtoMessage)) != 1 {
+		t.Fatalf("got %d children, want 1", len(f.Value.(ProtoMessage)))
+	}
+	c := f.Value.(ProtoMessage)[0]
+	if c.ID != 1 || c.WireType != protowire.VarintType || c.Value != float64(100) {
+		t.Errorf("child: number=%d wire=%q val=%#v", c.ID, c.WireType, c.Value)
+	}
+}
+
+func TestWalkProtoMessage_NestedMessagesTwoLevels(t *testing.T) {
+	// Level 2: innermost
+	l2 := protowire.AppendTag(nil, 1, protowire.VarintType)
+	l2 = protowire.AppendVarint(l2, 42)
+
+	// Level 1: wraps l2
+	l1 := protowire.AppendTag(nil, 1, protowire.BytesType)
+	l1 = protowire.AppendBytes(l1, l2)
+
+	// Level 0: top-level, wraps l1
+	l0 := protowire.AppendTag(nil, 1, protowire.BytesType)
+	l0 = protowire.AppendBytes(l0, l1)
+
+	pm, err := WalkProtoMessage(l0)
+	if err != nil {
+		t.Fatalf("WalkProtoMessage: %v", err)
+	}
+	if len(pm) != 1 {
+		t.Fatalf("got %d fields, want 1", len(pm))
+	}
+	f0 := pm[0]
+	if len(f0.Value.(ProtoMessage)) != 1 {
+		t.Fatalf("level 0: got %d children, want 1", len(f0.Value.(ProtoMessage)))
+	}
+	f1 := f0.Value.(ProtoMessage)[0]
+	if len(f1.Value.(ProtoMessage)) != 1 {
+		t.Fatalf("level 1: got %d children, want 1", len(f1.Value.(ProtoMessage)))
+	}
+	f2 := f1.Value.(ProtoMessage)[0]
+	if f2.Value != float64(42) {
+		t.Errorf("level 2 value = %#v, want 42", f2.Value)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WalkProtoMessage  --  Empty / Truncated / Group
+// ---------------------------------------------------------------------------
+
+func TestWalkProtoMessage_EmptyMessage(t *testing.T) {
+	pm, err := WalkProtoMessage(nil)
+	if err != nil {
+		t.Fatalf("WalkProtoMessage: %v", err)
+	}
+	if len(pm) != 0 {
+		t.Errorf("Fields length = %d, want 0", len(pm))
+	}
+
+	pm, err = WalkProtoMessage([]byte{})
+	if err != nil {
+		t.Fatalf("WalkProtoMessage: %v", err)
+	}
+	if len(pm) != 0 {
+		t.Errorf("Fields length = %d, want 0", len(pm))
+	}
+}
+
+func TestWalkProtoMessage_TruncatedTag(t *testing.T) {
+	// Incomplete varint tag (MSB set but no continuation)
+	data := []byte{0x80}
+	_, err := WalkProtoMessage(data)
+	if err == nil {
+		t.Fatal("expected error for truncated protobuf tag, got nil")
+	}
+	if !strings.Contains(err.Error(), "truncated") {
+		t.Errorf("error = %q, want error containing 'truncated'", err.Error())
+	}
+}
+
+func TestWalkProtoMessage_TruncatedVarint(t *testing.T) {
+	// Valid tag, then incomplete varint value
+	b := protowire.AppendTag(nil, 1, protowire.VarintType)
+	b = append(b, 0x80) // MSB set, expecting continuation
+	_, err := WalkProtoMessage(b)
+	if err == nil {
+		t.Fatal("expected error for truncated varint, got nil")
+	}
+	if !strings.Contains(err.Error(), "truncated") {
+		t.Errorf("error = %q, want error containing 'truncated'", err.Error())
+	}
+}
+
+func TestWalkProtoMessage_TruncatedFixed32(t *testing.T) {
+	b := protowire.AppendTag(nil, 1, protowire.Fixed32Type)
+	b = append(b, 0x01, 0x02) // only 2 bytes, need 4
+	_, err := WalkProtoMessage(b)
+	if err == nil {
+		t.Fatal("expected error for truncated fixed32, got nil")
+	}
+}
+
+func TestWalkProtoMessage_TruncatedFixed64(t *testing.T) {
+	b := protowire.AppendTag(nil, 1, protowire.Fixed64Type)
+	b = append(b, 0x01, 0x02, 0x03) // only 3 bytes, need 8
+	_, err := WalkProtoMessage(b)
+	if err == nil {
+		t.Fatal("expected error for truncated fixed64, got nil")
+	}
+}
+
+func TestWalkProtoMessage_TruncatedLengthDelimited(t *testing.T) {
+	// Tag says bytes type, then a length varint of 5, but only 2 bytes follow
+	b := protowire.AppendTag(nil, 1, protowire.BytesType)
+	// Append length = 5 as a varint, then only 2 bytes
+	b = append(b, 0x05, 0x01, 0x02)
+	_, err := WalkProtoMessage(b)
+	if err == nil {
+		t.Fatal("expected error for truncated length-delimited, got nil")
+	}
+	if !strings.Contains(err.Error(), "truncated") {
+		t.Errorf("error = %q, want error containing 'truncated'", err.Error())
+	}
+}
+
+func TestWalkProtoMessage_GroupWireType(t *testing.T) {
+	b := protowire.AppendTag(nil, 1, protowire.StartGroupType)
+	b = protowire.AppendTag(b, 2, protowire.VarintType)
+	b = protowire.AppendVarint(b, 42)
+	b = protowire.AppendTag(b, 1, protowire.EndGroupType)
+
+	pm, err := WalkProtoMessage(b)
+	if err != nil {
+		t.Fatalf("WalkProtoMessage: %v", err)
+	}
+	if len(pm) != 1 {
+		t.Fatalf("got %d fields, want 1", len(pm))
+	}
+	f := pm[0]
+	if f.ID != 1 {
+		t.Errorf("ID = %d, want 1", f.ID)
+	}
+	children, ok := f.Value.(ProtoMessage)
+	if !ok {
+		t.Fatalf("Value type = %T, want ProtoMessage", f.Value)
+	}
+	if len(children) != 1 || children[0].ID != 2 || children[0].Value != float64(42) {
+		t.Errorf("children = %+v, want [{ID:2, Value:42}]", children)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WalkProtoMessage  --  Depth limit
+// ---------------------------------------------------------------------------
+
+func TestWalkProtoMessage_DepthLimit(t *testing.T) {
+	// Build a simple valid message (varint field 1 = 0).
+	msg := protowire.AppendTag(nil, 1, protowire.VarintType)
+	msg = protowire.AppendVarint(msg, 0)
+
+	// At depth 63, walkFields should succeed.
+	_, _, err := walkFields(msg, 63)
+	if err != nil {
+		t.Fatalf("walkFields at depth 63: unexpected error: %v", err)
+	}
+
+	// At depth 64, walkFields should return the depth limit error.
+	_, _, err = walkFields(msg, 64)
+	if err == nil {
+		t.Fatal("walkFields at depth 64: expected depth limit error, got nil")
+	}
+	if !strings.Contains(err.Error(), "depth") {
+		t.Errorf("error = %q, want error containing 'depth'", err.Error())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WalkProtoMessage  --  Any detection & auto-unwrap
+// ---------------------------------------------------------------------------
+
+func mustMarshalAny(m proto.Message) []byte {
+	inner, err := proto.Marshal(m)
+	if err != nil {
+		panic(err)
+	}
+	a := &anypb.Any{
+		TypeUrl: "type.googleapis.com/" + string(m.ProtoReflect().Descriptor().FullName()),
+		Value:   inner,
+	}
+	b, err := proto.Marshal(a)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func TestWalkProtoMessage_AnyAutoUnwrap(t *testing.T) {
+	anyBytes := mustMarshalAny(&wrapperspb.UInt64Value{Value: 42})
+
+	pm, err := WalkProtoMessage(anyBytes)
+	if err != nil {
+		t.Fatalf("WalkProtoMessage(Any): %v", err)
+	}
+	// Top-level Any is not auto-unwrapped; returned as 2 raw fields.
+	if len(pm) != 2 {
+		t.Fatalf("got %d fields, want 2", len(pm))
+	}
+	// f0: type_url string field
+	if pm[0].ID != 1 {
+		t.Errorf("f0.ID = %d, want 1", pm[0].ID)
+	}
+	typeURL, ok := pm[0].Value.(string)
+	if !ok {
+		t.Fatalf("f0.Value type = %T, want string (type_url)", pm[0].Value)
+	}
+	if !strings.HasPrefix(typeURL, "type.googleapis.com/") {
+		t.Errorf("typeURL = %q, want prefix type.googleapis.com/", typeURL)
+	}
+	// f1: value bytes, recursed into inner message
+	if pm[1].ID != 2 {
+		t.Errorf("f1.ID = %d, want 2", pm[1].ID)
+	}
+	children, ok := pm[1].Value.(ProtoMessage)
+	if !ok {
+		t.Fatalf("f1.Value type = %T, want ProtoMessage", pm[1].Value)
+	}
+	if len(children) == 0 {
+		t.Fatal("Children empty; want recursed inner fields")
+	}
+	if children[0].ID != 1 || children[0].Value != float64(42) {
+		t.Errorf("children[0] = %+v, want ID=1 Value=42", children[0])
+	}
+}
+
+func TestWalkProtoMessage_AnyAutoUnwrap_NestedChildren(t *testing.T) {
+	// Create an Any containing a wrapper with a larger value
+	anyBytes := mustMarshalAny(&wrapperspb.UInt64Value{Value: 999})
+
+	pm, err := WalkProtoMessage(anyBytes)
+	if err != nil {
+		t.Fatalf("WalkProtoMessage(Any): %v", err)
+	}
+	// Top-level Any is not auto-unwrapped.
+	if len(pm) != 2 {
+		t.Fatalf("got %d fields, want 2", len(pm))
+	}
+	// f1 contains the recursed inner message children
+	children, ok := pm[1].Value.(ProtoMessage)
+	if !ok {
+		t.Fatalf("f1.Value type = %T, want ProtoMessage", pm[1].Value)
+	}
+	if len(children) == 0 {
+		t.Error("Children not populated for Any inner message")
+	}
+}
+
+func TestWalkProtoMessage_AnyNestedInRegularMessage(t *testing.T) {
+	// Build a regular message that contains an Any as field 3 (bytes)
+	anyBytes := mustMarshalAny(&wrapperspb.UInt64Value{Value: 42})
+
+	outer := protowire.AppendTag(nil, 1, protowire.VarintType)
+	outer = protowire.AppendVarint(outer, 1)
+	outer = protowire.AppendTag(outer, 3, protowire.BytesType)
+	outer = protowire.AppendBytes(outer, anyBytes)
+
+	pm, err := WalkProtoMessage(outer)
+	if err != nil {
+		t.Fatalf("WalkProtoMessage: %v", err)
+	}
+	if len(pm) != 2 {
+		t.Fatalf("got %d fields, want 2", len(pm))
+	}
+	anyField := pm[1]
+	if anyField.ID != 3 {
+		t.Errorf("ID = %d, want 3", anyField.ID)
+	}
+	if anyField.Type == "" {
+		t.Error("Type not set on Any field nested in regular message")
+	}
+	// Registered type: Value is json.RawMessage (decoded), not ProtoMessage
+	if anyField.Value == nil {
+		t.Error("Value is nil; want decoded json.RawMessage for registered Any type")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RegisterProtoType
+// ---------------------------------------------------------------------------
+
+func clearRegistry() {
+	registryMu.Lock()
+	registryTypes = map[string]proto.Message{}
+	registryMu.Unlock()
+}
+
+func TestRegisterProtoType_NilPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("RegisterProtoType(nil) did not panic")
+		}
+	}()
+	RegisterProtoType(nil)
+}
+
+func TestRegisterProtoType_WithMatchingAny(t *testing.T) {
+	clearRegistry()
+
+	// Register the UInt64 wrapper type
+	RegisterProtoType(&wrapperspb.UInt64Value{Value: 0})
+
+	anyBytes := mustMarshalAny(&wrapperspb.UInt64Value{Value: 42})
+
+	// Wrap Any in a regular message (field 1=varint, field 3=bytes with Any)
+	outer := protowire.AppendTag(nil, 1, protowire.VarintType)
+	outer = protowire.AppendVarint(outer, 1)
+	outer = protowire.AppendTag(outer, 3, protowire.BytesType)
+	outer = protowire.AppendBytes(outer, anyBytes)
+
+	pm, err := WalkProtoMessage(outer)
+	if err != nil {
+		t.Fatalf("WalkProtoMessage: %v", err)
+	}
+	if len(pm) != 2 {
+		t.Fatalf("got %d fields, want 2", len(pm))
+	}
+	f := pm[1]
+	if f.ID != 3 {
+		t.Errorf("ID = %d, want 3", f.ID)
+	}
+	if f.Type == "" {
+		t.Fatal("Type not populated")
+	}
+	// Registered type: Value is json.RawMessage (decoded), not ProtoMessage
+	rawJSON, ok := f.Value.(json.RawMessage)
+	if !ok {
+		t.Fatalf("Value type = %T, want json.RawMessage (decoded for registered type)", f.Value)
+	}
+
+	// Validate the decoded JSON — wrapper types (UInt64Value) marshal as their
+	// inner value via protojson, not as an object with a "value" key.
+	var decoded string
+	if err := json.Unmarshal(rawJSON, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal Decoded JSON: %v (raw: %s)", err, string(rawJSON))
+	}
+	if decoded != "0" {
+		t.Errorf("decoded value = %q, want %q", decoded, "0")
+	}
+}
+
+func TestRegisterProtoType_WithNonMatchingAny(t *testing.T) {
+	clearRegistry()
+
+	// Register a different type (StringValue instead of UInt64Value)
+	RegisterProtoType(&wrapperspb.StringValue{Value: "ignored"})
+
+	// Marshal an Any containing UInt64Value (doesn't match StringValue)
+	anyBytes := mustMarshalAny(&wrapperspb.UInt64Value{Value: 42})
+
+	// Wrap in a regular message
+	outer := protowire.AppendTag(nil, 1, protowire.VarintType)
+	outer = protowire.AppendVarint(outer, 1)
+	outer = protowire.AppendTag(outer, 3, protowire.BytesType)
+	outer = protowire.AppendBytes(outer, anyBytes)
+
+	pm, err := WalkProtoMessage(outer)
+	if err != nil {
+		t.Fatalf("WalkProtoMessage: %v", err)
+	}
+	f := pm[1]
+	if f.Type == "" {
+		t.Error("Type should still be populated")
+	}
+	// Non-matching type: Value is ProtoMessage (children), not decoded JSON
+	children, ok := f.Value.(ProtoMessage)
+	if !ok {
+		t.Fatalf("Value type = %T, want ProtoMessage (non-matching type)", f.Value)
+	}
+	if len(children) == 0 {
+		t.Error("Children should still be present")
+	}
+}
+
+func TestRegisterProtoType_ConcurrentSafety(t *testing.T) {
+	clearRegistry()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			RegisterProtoType(&wrapperspb.UInt64Value{Value: 0})
+		}()
+	}
+	wg.Wait()
+
+	// Verify it's registered
+	_, ok := lookupRegisteredType("type.googleapis.com/google.protobuf.UInt64Value")
+	if !ok {
+		t.Fatal("type not found in registry after concurrent registration")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WalkProtoMessage  --  Multi-field smoke test
+// ---------------------------------------------------------------------------
+
+func TestWalkProtoMessage_MultipleFields(t *testing.T) {
+	var b []byte
+	b = protowire.AppendTag(b, 1, protowire.VarintType)
+	b = protowire.AppendVarint(b, 10)
+	b = protowire.AppendTag(b, 2, protowire.Fixed64Type)
+	b = protowire.AppendFixed64(b, 0xABCD)
+	b = protowire.AppendTag(b, 3, protowire.BytesType)
+	b = protowire.AppendBytes(b, []byte("hello"))
+
+	pm, err := WalkProtoMessage(b)
+	if err != nil {
+		t.Fatalf("WalkProtoMessage: %v", err)
+	}
+	if len(pm) != 3 {
+		t.Fatalf("got %d fields, want 3", len(pm))
+	}
+
+	if pm[0].ID != 1 || pm[0].Value != float64(10) {
+		t.Errorf("field 0: %+v", pm[0])
+	}
+	if pm[1].ID != 2 || pm[1].Value != float64(0xABCD) {
+		t.Errorf("field 1: %+v", pm[1])
+	}
+	if pm[2].ID != 3 {
+		t.Errorf("field 2: ID=%d, want 3", pm[2].ID)
+	}
+	if _, ok := pm[2].Value.(ProtoMessage); !ok {
+		t.Errorf("field 2: Value type = %T, want ProtoMessage (printable bytes parsed as nested)", pm[2].Value)
+	}
+	}


### PR DESCRIPTION
During roll out of a new version one replica paniced on a data consistency assert. So we had to understand what led to that object state. We needed a tool to inspect in production environment what RSM operations led to the node crash. 

Our objects that failed have an epoch version that corresponds to the Raft commit index. So we were able to disect what Raft commit pushed this specific object version to the Raft SM. Then, by looking around this specific commit with this tool (logdump) we were able to identify specific subset of Raft commits (proposals) that were differently executed by the leader and a replica. And that allowed us to bisect the code changes that led to the bug. And all that was only possible because we were able to scan over the Raft log with this tool.

The patch introduces a new tool `/tools/logdump` that is capable of describing the current raft state and scan over the commit log (Currently based on PebbleDB). It can also bypass LOCK file flock() lease. It opens PebbleDB in read-only mode. It touches no Dragonboat code. The tool can decode Raft log entries as well as it can abstractly decode Entry.Cmd payload if it is encoded in Protobuf.

```
$ ./logdump describe ~/raft.1/node-1/dragonboat-1

MANIFEST: Address=10.32.179.88:62901, BinVer=100, HardHash=0, LogdbType=sharded-pebble, Hostname=ieprisyazhniy-dev, DeploymentId=1, StepWorkerCount=16, LogdbShardCount=16, MaxSessionCount=4096, EntryBatchSize=48, AddressByNodeHostId=false
CLUSTER   NODE   TERM   VOTE   COMMIT   ENTRIES   RANGE              SNAPSHOTS   BOOTSTRAP
1         1      20     1      138323   8311      [130013..138323]   3           join=false, 1 addrs, sm=OnDiskStateMachine
2         1      14     2      65289    5284      [60006..65289]     3           join=false, 1 addrs, sm=OnDiskStateMachine
3         1      16     1      65255    5250      [60006..65255]     3           join=false, 1 addrs, sm=OnDiskStateMachine
4         1      21     2      65254    5249      [60006..65254]     3           join=false, 1 addrs, sm=OnDiskStateMachine
5         1      9      1      65249    5244      [60006..65249]     3           join=false, 1 addrs, sm=OnDiskStateMachine
6         1      15     1      65253    5248      [60006..65253]     3           join=false, 1 addrs, sm=OnDiskStateMachine
7         1      12     2      65254    5249      [60006..65254]     3           join=false, 1 addrs, sm=OnDiskStateMachine
8         1      14     2      65256    5251      [60006..65256]     3           join=false, 1 addrs, sm=OnDiskStateMachine

$ ./logdump scan ~/raft.1/node-1/dragonboat-1 --cluster 1 --node 1 --limit 10
── state: cluster=1 node=1 ──
Term: 20, Vote: 1, Commit: 138323

── snapshots ──
INDEX    TERM   MEMBERS
110011   5      1 addrs
120012   5      1 addrs
130013   13     2 addrs

── entries ──
INDEX   TERM   TYPE              KEY                  CLIENT               SERIES   RESPTO   CMD
30013   5      ── EncodedEntry   0xa134bc077ad7f458   0x42ff9364aa44cea2   0        0        000a144a120a... (522 B)
30014   5      ── EncodedEntry   0x1e8a5f4ae48b2c6c   0x42ff9364aa44cea2   0        0        000a98044295... (1039 B)
30015   5      ── EncodedEntry   0x5a47c7aff4c8a919   0x42ff9364aa44cea2   0        0        000a144a120a... (522 B)
30016   5      ── EncodedEntry   0x8806b63e174d9b6c   0x42ff9364aa44cea2   0        0        000a98044295... (1039 B)
30017   5      ── EncodedEntry   0x3da027462db44f57   0x42ff9364aa44cea2   0        0        000a144a120a... (522 B)
30018   5      ── EncodedEntry   0xd6004714bdf7a331   0x42ff9364aa44cea2   0        0        000a98044295... (1039 B)
30019   5      ── EncodedEntry   0x42a4602926019a36   0x42ff9364aa44cea2   0        0        000a144a120a... (522 B)
30020   5      ── EncodedEntry   0x47fc08b20c1f73c8   0x42ff9364aa44cea2   0        0        000a98044295... (1039 B)
30021   5      ── EncodedEntry   0xc1f770be4b966260   0x42ff9364aa44cea2   0        0        000a144a120a... (522 B)
30022   5      ── EncodedEntry   0x91185642ccb77b89   0x42ff9364aa44cea2   0        0        000a98044295... (1039 B)

$ ./logdump scan ~/raft.1/node-1/dragonboat-1 --cluster 3 --node 1 --index 65000 --format json
{"cluster_id":3,"node_id":1,"state":{"term":16,"vote":1,"commit":65255},"snapshots":[{"index":40004,"term":5,"members":1},{"index":50005,"term":5,"members":1},{"index":60006,"term":9,"members":2}],"entries":[{"index":65000,"term":16,"type":"EncodedEntry","key":15160884136415968393,"client_id":11516911269575256109,"series_id":0,"responded_to":0,"cmd":"000a9...<<hex>>"}],"from":65000,"to":65001,"limit":100,"first_index":60006,"last_index":65255,"entry_count":5250}

$ ./logdump scan ~/raft.1/node-1/dragonboat-1 --cluster 3 --node 1 --index 65000 --format json -decode-entry-header
{"cluster_id":3,"node_id":1,"state":{"term":16,"vote":1,"commit":65255},"snapshots":[{"index":40004,"term":5,"members":1},{"index":50005,"term":5,"members":1},{"index":60006,"term":9,"members":2}],"entries":[{"index":65000,"term":16,"type":"EncodedEntry","key":15160884136415968393,"client_id":11516911269575256109,"series_id":0,"responded_to":0,"cmd":{"kind":"encoded_entry","encoded_entry":{"version":0,"compression":"none","size":1038,"payload_hex":"0a9...<<hex>>"}}}],"from":65000,"to":65001,"limit":100,"first_index":60006,"last_index":65255,"entry_count":5250}

$ ./logdump scan ~/raft.1/node-1/dragonboat-1 --cluster 3 --node 1 --index 65000 --format json -decode-entry-header -decode-entry-cmd
{"cluster_id":3,"node_id":1,"state":{"term":16,"vote":1,"commit":65255},"snapshots":[{"index":40004,"term":5,"members":1},{"index":50005,"term":5,"members":1},{"index":60006,"term":9,"members":2}],"entries":[{"index":65000,"term":16,"type":"EncodedEntry","key":15160884136415968393,"client_id":11516911269575256109,"series_id":0,"responded_to":0,"cmd":{"kind":"encoded_entry","encoded_entry":{"version":0,"compression":"none","size":1038,"proto_message":[{"id":1,"value":[{"id":8,"value":[{"id":1,"value":"module.raft.updateCacheProc"},{"id":2,"type_url":"type.googleapis.com/internalpb.ArrayOfAny","value":[{"id":1,"type_url":"type.googleapis.com/...}],"from":65000,"to":65001,"limit":100,"first_index":60006,"last_index":65255,"entry_count":5250}
```